### PR TITLE
Ledger replay prototype

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -364,11 +364,15 @@ target_sources (rippled PRIVATE
   src/ripple/app/ledger/impl/InboundLedgers.cpp
   src/ripple/app/ledger/impl/InboundTransactions.cpp
   src/ripple/app/ledger/impl/LedgerCleaner.cpp
+  src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
   src/ripple/app/ledger/impl/LedgerMaster.cpp
   src/ripple/app/ledger/impl/LedgerReplay.cpp
+  src/ripple/app/ledger/impl/LedgerReplayer.cpp
+  src/ripple/app/ledger/impl/LedgerReplayTask.cpp
   src/ripple/app/ledger/impl/LedgerToJson.cpp
   src/ripple/app/ledger/impl/LocalTxs.cpp
   src/ripple/app/ledger/impl/OpenLedger.cpp
+  src/ripple/app/ledger/impl/SkipListAcquire.cpp
   src/ripple/app/ledger/impl/TransactionAcquire.cpp
   src/ripple/app/ledger/impl/TransactionMaster.cpp
   src/ripple/app/main/Application.cpp

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -368,11 +368,13 @@ target_sources (rippled PRIVATE
   src/ripple/app/ledger/impl/LedgerMaster.cpp
   src/ripple/app/ledger/impl/LedgerReplay.cpp
   src/ripple/app/ledger/impl/LedgerReplayer.cpp
+  src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
   src/ripple/app/ledger/impl/LedgerReplayTask.cpp
   src/ripple/app/ledger/impl/LedgerToJson.cpp
   src/ripple/app/ledger/impl/LocalTxs.cpp
   src/ripple/app/ledger/impl/OpenLedger.cpp
   src/ripple/app/ledger/impl/SkipListAcquire.cpp
+  src/ripple/app/ledger/impl/TimeoutCounter.cpp
   src/ripple/app/ledger/impl/TransactionAcquire.cpp
   src/ripple/app/ledger/impl/TransactionMaster.cpp
   src/ripple/app/main/Application.cpp

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -769,6 +769,17 @@
 #   to track a particular network.
 #
 #
+# [ledger_replay]
+#
+#   0 or 1.
+#
+#   0: Disable the ledger replay feature [default]
+#   1: Enable the ledger replay feature. With this feature enabled, when
+#      acquiring a ledger from the network, a rippled node only downloads
+#      the ledger header and the transactions instead of the whole ledger.
+#      And the ledger is built by applying the transactions to the parent
+#      ledger.
+#
 #-------------------------------------------------------------------------------
 #
 # 4. HTTPS Client

--- a/src/ripple/app/ledger/InboundLedger.h
+++ b/src/ripple/app/ledger/InboundLedger.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_APP_LEDGER_INBOUNDLEDGER_H_INCLUDED
 #define RIPPLE_APP_LEDGER_INBOUNDLEDGER_H_INCLUDED
 
+#include <ripple/app/ledger/impl/TimeoutCounter.h>
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/basics/CountedObject.h>
@@ -31,7 +32,7 @@
 namespace ripple {
 
 // A ledger we are trying to acquire
-class InboundLedger final : public PeerSet,
+class InboundLedger final : public TimeoutCounter,
                             public std::enable_shared_from_this<InboundLedger>,
                             public CountedObject<InboundLedger>
 {
@@ -60,7 +61,8 @@ public:
         uint256 const& hash,
         std::uint32_t seq,
         Reason reason,
-        clock_type&);
+        clock_type&,
+        std::unique_ptr<PeerSet> peerSet);
 
     ~InboundLedger();
 
@@ -155,19 +157,10 @@ private:
     void
     queueJob() override;
 
-    void
-    onPeerAdded(std::shared_ptr<Peer> const& peer) override
-    {
-        // For historical nodes, do not trigger too soon
-        // since a fetch pack is probably coming
-        if (mReason != Reason::HISTORY)
-            trigger(peer, TriggerReason::added);
-    }
-
     std::size_t
     getPeerCount() const;
 
-    std::weak_ptr<PeerSet>
+    std::weak_ptr<TimeoutCounter>
     pmDowncast() override;
 
     int
@@ -211,6 +204,7 @@ private:
     std::mutex mReceivedDataLock;
     std::vector<PeerDataPairType> mReceivedData;
     bool mReceiveDispatched;
+    std::unique_ptr<PeerSet> mPeerSet;
 };
 
 /** Deserialize a ledger header from a byte array. */

--- a/src/ripple/app/ledger/InboundLedger.h
+++ b/src/ripple/app/ledger/InboundLedger.h
@@ -20,8 +20,8 @@
 #ifndef RIPPLE_APP_LEDGER_INBOUNDLEDGER_H_INCLUDED
 #define RIPPLE_APP_LEDGER_INBOUNDLEDGER_H_INCLUDED
 
-#include <ripple/app/ledger/impl/TimeoutCounter.h>
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/ledger/impl/TimeoutCounter.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/basics/CountedObject.h>
 #include <ripple/overlay/PeerSet.h>

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -56,7 +56,7 @@ namespace ripple {
 
 create_genesis_t const create_genesis{};
 
-static uint256
+uint256
 calculateLedgerHash(LedgerInfo const& info)
 {
     // VFALCO This has to match addRaw in View.h.

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -459,6 +459,9 @@ deserializeTx(SHAMapItem const& item);
 std::pair<std::shared_ptr<STTx const>, std::shared_ptr<STObject const>>
 deserializeTxPlusMeta(SHAMapItem const& item);
 
+uint256
+calculateLedgerHash(LedgerInfo const& info);
+
 }  // namespace ripple
 
 #endif

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -290,15 +290,6 @@ public:
     boost::optional<LedgerIndex>
     minSqlSeq();
 
-    // TODO move into LedgerMaster??
-    protocol::TMProofPathResponse
-    getProofPathResponse(
-        std::shared_ptr<protocol::TMProofPathRequest> const& request);
-
-    protocol::TMReplayDeltaResponse
-    getReplayDeltaResponse(
-        std::shared_ptr<protocol::TMReplayDeltaRequest> const& request);
-
 private:
     void
     setValidLedger(std::shared_ptr<Ledger const> const& l);

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -290,6 +290,15 @@ public:
     boost::optional<LedgerIndex>
     minSqlSeq();
 
+    // TODO move into LedgerMaster??
+    protocol::TMProofPathResponse
+    getProofPathResponse(
+        std::shared_ptr<protocol::TMProofPathRequest> const& request);
+
+    protocol::TMReplayDeltaResponse
+    getReplayDeltaResponse(
+        std::shared_ptr<protocol::TMReplayDeltaRequest> const& request);
+
 private:
     void
     setValidLedger(std::shared_ptr<Ledger const> const& l);

--- a/src/ripple/app/ledger/LedgerReplay.h
+++ b/src/ripple/app/ledger/LedgerReplay.h
@@ -40,6 +40,11 @@ public:
         std::shared_ptr<Ledger const> parent,
         std::shared_ptr<Ledger const> replay);
 
+    LedgerReplay(
+        std::shared_ptr<Ledger const> parent,
+        std::shared_ptr<Ledger const> replay,
+        std::map<std::uint32_t, std::shared_ptr<STTx const>>&& orderedTxns);
+
     /** @return The parent of the ledger to replay
      */
     std::shared_ptr<Ledger const> const&

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -38,21 +38,15 @@ class LedgerReplayTask final
       public CountedObject<LedgerReplayTask>
 {
 public:
-    enum class SubTaskType {
-        START_LEDGER,  // Acquiring the first ledger of the task
-        SKIP_LIST,     // Acquiring the skip list
-        LEDGER_DELTA,  // Acquiring a ledger delta
-    };
-
     struct TaskParameter
     {
-        uint256 startLedgerHash;
+        InboundLedger::Reason reason;
         uint256 finishLedgerHash;
-        std::uint32_t startLedgerSeq;
+        uint256 startLedgerHash;
         std::uint32_t finishLedgerSeq;
+        std::uint32_t startLedgerSeq;
         std::uint32_t ledgersToBuild;  // including the start and the finish
         std::vector<uint256> skipList;
-        InboundLedger::Reason reason;
 
         bool
         isValid() const  // TODO name
@@ -153,13 +147,11 @@ public:
         Application& app,
         std::shared_ptr<SkipListAcquire>& skipListAcquirer,
         TaskParameter&& parameter);
+
     ~LedgerReplayTask() = default;
 
     void
-    init()
-    {
-        trigger();
-    }
+    init();
 
     void
     updateSkipList(
@@ -177,7 +169,7 @@ public:
     }
 
     void
-    subTaskFailed(SubTaskType type);
+    subTaskFailed(uint256 const& hash);
 
 private:
     void
@@ -191,14 +183,14 @@ private:
     {
     }
 
+    std::weak_ptr<PeerSet>
+    pmDowncast() override;
+
     void
     done();
 
     void
     trigger();
-
-    std::weak_ptr<PeerSet>
-    pmDowncast() override;
 
     TaskParameter parameter_;
     std::shared_ptr<SkipListAcquire> skipListAcquirer_;
@@ -211,3 +203,10 @@ private:
 }  // namespace ripple
 
 #endif
+
+//    enum class SubTaskType {
+//        START_LEDGER,  // Acquiring the first ledger of the task
+//        SKIP_LIST,     // Acquiring the skip list
+//        LEDGER_DELTA,  // Acquiring a ledger delta
+//    };
+//

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -1,0 +1,213 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_LEDGER_LEDGERREPLAYTASK_H_INCLUDED
+#define RIPPLE_APP_LEDGER_LEDGERREPLAYTASK_H_INCLUDED
+
+#include <ripple/app/ledger/InboundLedger.h>
+#include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/overlay/PeerSet.h>
+#include <ripple/shamap/SHAMap.h>
+#include <queue>
+
+namespace ripple {
+
+class LedgerDeltaAcquire;
+class SkipListAcquire;
+
+class LedgerReplayTask final
+    : public PeerSet,  // TODO using PeerSet's timer, change??
+      public std::enable_shared_from_this<LedgerReplayTask>,
+      public CountedObject<LedgerReplayTask>
+{
+public:
+    enum class SubTaskType {
+        START_LEDGER,  // Acquiring the first ledger of the task
+        SKIP_LIST,     // Acquiring the skip list
+        LEDGER_DELTA,  // Acquiring a ledger delta
+    };
+
+    struct TaskParameter
+    {
+        uint256 startLedgerHash;
+        uint256 finishLedgerHash;
+        std::uint32_t startLedgerSeq;
+        std::uint32_t finishLedgerSeq;
+        std::uint32_t ledgersToBuild;  // including the start and the finish
+        std::vector<uint256> skipList;
+        InboundLedger::Reason reason;
+
+        bool
+        isValid() const  // TODO name
+        {
+            if (finishLedgerHash.isZero())
+                return false;
+            if (ledgersToBuild > 256)
+                return false;
+
+            if (startLedgerSeq != 0 && finishLedgerSeq != 0)
+            {
+                auto size = finishLedgerSeq - startLedgerSeq + 1;
+                if (size > 256)
+                    return false;
+                if (ledgersToBuild != 0 && ledgersToBuild != size)
+                    return false;
+            }
+            return true;
+        }
+
+        bool
+        update(
+            uint256 const& hash,
+            std::uint32_t seq,
+            std::vector<uint256> const& sList)
+        {
+            if (!isValid())
+                return false;
+
+            if (finishLedgerHash != hash)
+                return false;
+            if (finishLedgerSeq != 0 && finishLedgerSeq != seq)
+                return false;
+            finishLedgerSeq = seq;
+
+            skipList = sList;
+            skipList.emplace_back(finishLedgerHash);
+            if (startLedgerHash.isZero() && !startLedgerSeq && !ledgersToBuild)
+            {
+                ledgersToBuild = 1;
+                startLedgerSeq = finishLedgerSeq;
+                startLedgerHash = finishLedgerHash;
+            }
+            else
+            {
+                if (startLedgerHash.isNonZero())
+                {
+                    auto i = std::find(
+                        skipList.begin(), skipList.end(), startLedgerHash);
+                    std::uint32_t size = skipList.end() - i;
+                    if (size == 0)
+                        return false;
+                    if (ledgersToBuild == 0)
+                        ledgersToBuild = size;
+                    if (startLedgerSeq == 0)
+                        startLedgerSeq = finishLedgerSeq - size + 1;
+                }
+                else
+                {
+                    if (ledgersToBuild != 0 && startLedgerSeq == 0)
+                        startLedgerSeq = finishLedgerSeq - ledgersToBuild + 1;
+                    if (ledgersToBuild == 0 && startLedgerSeq != 0)
+                        ledgersToBuild = finishLedgerSeq - startLedgerSeq + 1;
+                    if (ledgersToBuild > skipList.size())
+                        return false;
+                    if (auto i = std::find(
+                            skipList.begin(), skipList.end(), startLedgerHash);
+                        i != skipList.end() && *i != startLedgerHash)
+                        return false;
+                    else
+                        startLedgerHash =
+                            skipList[skipList.size() - ledgersToBuild];
+                }
+            }
+
+            if (!isValid())
+                return false;
+            return true;
+        }
+
+        bool
+        canMergeInto(TaskParameter const& existingTask)
+        {
+            // TODO
+            return false;
+        }
+    };
+
+    static char const*
+    getCountedObjectName()
+    {
+        return "LedgerReplayTask";
+    }
+
+    using pointer = std::shared_ptr<LedgerReplayTask>;
+
+    LedgerReplayTask(
+        Application& app,
+        std::shared_ptr<SkipListAcquire>& skipListAcquirer,
+        TaskParameter&& parameter);
+    ~LedgerReplayTask() = default;
+
+    void
+    init()
+    {
+        trigger();
+    }
+
+    void
+    updateSkipList(
+        uint256 const& hash,
+        std::uint32_t seq,
+        std::vector<ripple::uint256> const& data);
+
+    void
+    tryAdvance(std::shared_ptr<Ledger const> const& ledger);
+
+    TaskParameter&
+    getTaskTaskParameter()
+    {
+        return parameter_;
+    }
+
+    void
+    subTaskFailed(SubTaskType type);
+
+private:
+    void
+    queueJob() override;
+
+    void
+    onTimer(bool progress, ScopedLockType& peerSetLock) override;
+
+    void
+    onPeerAdded(std::shared_ptr<Peer> const& peer) override
+    {
+    }
+
+    void
+    done();
+
+    void
+    trigger();
+
+    std::weak_ptr<PeerSet>
+    pmDowncast() override;
+
+    TaskParameter parameter_;
+    std::shared_ptr<SkipListAcquire> skipListAcquirer_;
+    // when it's done, ledgers_.size() == deltas_.size() + 1
+    // TODO keeping too many ledgers??
+    std::vector<std::shared_ptr<Ledger const>> ledgers_;
+    std::vector<std::shared_ptr<LedgerDeltaAcquire>> deltas_;
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -113,7 +113,7 @@ public:
     }
 
     void
-    deltaReady();
+    deltaReady(uint256 const& deltaHash);
 
     void
     cancel();

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -87,6 +87,7 @@ public:
 
     LedgerReplayTask(
         Application& app,
+        InboundLedgers& inboundLedgers,
         std::shared_ptr<SkipListAcquire>& skipListAcquirer,
         TaskParameter&& parameter);
 
@@ -135,6 +136,7 @@ private:
     void
     tryAdvance(ScopedLockType& peerSetLock);
 
+    InboundLedgers& inboundLedgers_;
     TaskParameter parameter_;
     std::shared_ptr<SkipListAcquire> skipListAcquirer_;
     std::shared_ptr<Ledger const> parent_ = {};

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -51,11 +51,11 @@ public:
     {
         InboundLedger::Reason reason;
         uint256 finishLedgerHash;
-        uint256 startLedgerHash;
-        std::uint32_t finishLedgerSeq;
-        std::uint32_t startLedgerSeq;
-        std::uint32_t ledgersToBuild;  // including the start and the finish
-        std::vector<uint256> skipList;
+        uint256 startLedgerHash = {};
+        std::uint32_t finishLedgerSeq = 0;
+        std::uint32_t startLedgerSeq = 0;
+        std::uint32_t ledgersToBuild = 0;  // including the start and the finish
+        std::vector<uint256> skipList = {};
 
         bool
         isValid() const  // TODO name

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -212,10 +212,3 @@ private:
 }  // namespace ripple
 
 #endif
-
-//    enum class SubTaskType {
-//        START_LEDGER,  // Acquiring the first ledger of the task
-//        SKIP_LIST,     // Acquiring the skip list
-//        LEDGER_DELTA,  // Acquiring a ledger delta
-//    };
-//

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -44,21 +44,19 @@ class LedgerReplayTask final
       public CountedObject<LedgerReplayTask>
 {
 public:
-    static auto constexpr TASK_TIMEOUT = 1000ms;
-    static auto constexpr SUB_TASK_TIMEOUT = 100ms;
-    static int constexpr SUB_TASK_MAX_TIMEOUTS = 10;
-
     struct TaskParameter
     {
-        //input
+        // input
         InboundLedger::Reason reason;
         uint256 finishHash;
         std::uint32_t totalLedgers;  // including the start and the finish
-        //to be filled
+        // to be filled
         std::uint32_t finishSeq = 0;
-        std::vector<uint256> skipList = {};// including the start and the finish
+        std::vector<uint256> skipList =
+            {};  // including the start and the finish
         uint256 startHash = {};
         std::uint32_t startSeq = 0;
+        bool full = false;
 
         TaskParameter(
             InboundLedger::Reason r,
@@ -88,8 +86,6 @@ public:
         return "LedgerReplayTask";
     }
 
-    using pointer = std::shared_ptr<LedgerReplayTask>;
-
     LedgerReplayTask(
         Application& app,
         LedgerReplayer& replayer,
@@ -105,16 +101,16 @@ public:
     updateSkipList(
         uint256 const& hash,
         std::uint32_t seq,
-        std::vector<ripple::uint256> const& data);
+        std::vector<ripple::uint256> const& sList);
 
     void
-    pushBackDeltaAcquire(std::shared_ptr<LedgerDeltaAcquire> delta);
+    addDelta(std::shared_ptr<LedgerDeltaAcquire> const& delta);
 
     void
-    tryAdvance(std::optional<std::shared_ptr<Ledger const> const> ledger);
+    tryAdvance();
 
-    TaskParameter&
-    getTaskTaskParameter()
+    TaskParameter const&
+    getTaskParameter() const
     {
         return parameter_;
     }

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -20,9 +20,9 @@
 #ifndef RIPPLE_APP_LEDGER_LEDGERREPLAYTASK_H_INCLUDED
 #define RIPPLE_APP_LEDGER_LEDGERREPLAYTASK_H_INCLUDED
 
-#include <ripple/app/ledger/impl/TimeoutCounter.h>
 #include <ripple/app/ledger/InboundLedger.h>
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/ledger/impl/TimeoutCounter.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/overlay/PeerSet.h>
 #include <ripple/shamap/SHAMap.h>
@@ -32,15 +32,18 @@ namespace ripple {
 
 using namespace std::chrono_literals;
 // Timeout interval in milliseconds
-auto constexpr LEDGER_REPLAY_TIMEOUT = 250ms;
+// TODO
+auto constexpr LEDGER_REPLAY_TIMEOUT = 100ms;
 
 enum {
-    LEDGER_REPLAY_NORM_TIMEOUTS = 4,
-    LEDGER_REPLAY_MAX_TIMEOUTS = 20,
+    LEDGER_REPLAY_MAX_TIMEOUTS = 10,
 };
 
 class LedgerDeltaAcquire;
 class SkipListAcquire;
+namespace test {
+class LedgerForwardReplay_test;
+}  // namespace test
 
 class LedgerReplayTask final
     : public TimeoutCounter,
@@ -50,7 +53,7 @@ class LedgerReplayTask final
 public:
     struct TaskParameter
     {
-        //TODO refactor after coding usa cases
+        // TODO refactor after coding usa cases
 
         InboundLedger::Reason reason;
         uint256 finishHash;
@@ -64,9 +67,9 @@ public:
             InboundLedger::Reason r,
             uint256 const& finishLedgerHash,
             std::uint32_t totalNumLedgers)
-        : reason(r)
-        , finishHash(finishLedgerHash)
-        , totalLedgers(totalNumLedgers)
+            : reason(r)
+            , finishHash(finishLedgerHash)
+            , totalLedgers(totalNumLedgers)
         {
             assert(isValid());
         }
@@ -174,7 +177,7 @@ public:
         std::shared_ptr<SkipListAcquire>& skipListAcquirer,
         TaskParameter&& parameter);
 
-    ~LedgerReplayTask() = default;
+    ~LedgerReplayTask();
 
     void
     init();
@@ -220,10 +223,10 @@ private:
     TaskParameter parameter_;
     std::shared_ptr<SkipListAcquire> skipListAcquirer_;
     std::shared_ptr<Ledger const> parent = {};
-    int deltaToBuild = -1; //should not build until have parent
+    int deltaToBuild = -1;  // should not build until have parent
     std::vector<std::shared_ptr<LedgerDeltaAcquire>> deltas_;
 
-    friend class LedgerForwardReplay_test;
+    friend class test::LedgerForwardReplay_test;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -169,6 +169,9 @@ public:
         std::vector<ripple::uint256> const& data);
 
     void
+    pushBackDeltaAcquire(std::shared_ptr<LedgerDeltaAcquire> delta);
+
+    void
     tryAdvance(std::optional<std::shared_ptr<Ledger const> const> ledger);
 
     TaskParameter&

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -35,7 +35,7 @@ using namespace std::chrono_literals;
 class LedgerDeltaAcquire;
 class SkipListAcquire;
 namespace test {
-class LedgerForwardReplay_test;
+class LedgerReplayClient;
 }  // namespace test
 
 class LedgerReplayTask final
@@ -88,6 +88,7 @@ public:
     LedgerReplayTask(
         Application& app,
         InboundLedgers& inboundLedgers,
+        LedgerReplayer& replayer,
         std::shared_ptr<SkipListAcquire>& skipListAcquirer,
         TaskParameter&& parameter);
 
@@ -137,13 +138,14 @@ private:
     tryAdvance(ScopedLockType& peerSetLock);
 
     InboundLedgers& inboundLedgers_;
+    LedgerReplayer& replayer_;
     TaskParameter parameter_;
     std::shared_ptr<SkipListAcquire> skipListAcquirer_;
     std::shared_ptr<Ledger const> parent_ = {};
     uint32_t deltaToBuild = 0;  // should not build until have parent
     std::vector<std::shared_ptr<LedgerDeltaAcquire>> deltas_;
 
-    friend class test::LedgerForwardReplay_test;
+    friend class test::LedgerReplayClient;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -88,7 +88,6 @@ public:
 
     LedgerReplayTask(
         Application& app,
-        LedgerReplayer& replayer,
         std::shared_ptr<SkipListAcquire>& skipListAcquirer,
         TaskParameter&& parameter);
 
@@ -137,7 +136,6 @@ private:
     void
     tryAdvance(ScopedLockType& peerSetLock);
 
-    LedgerReplayer& replayer_;
     TaskParameter parameter_;
     std::shared_ptr<SkipListAcquire> skipListAcquirer_;
     std::shared_ptr<Ledger const> parent_ = {};

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -106,9 +106,6 @@ public:
     void
     addDelta(std::shared_ptr<LedgerDeltaAcquire> const& delta);
 
-    void
-    tryAdvance();
-
     TaskParameter const&
     getTaskParameter() const
     {
@@ -116,7 +113,13 @@ public:
     }
 
     void
+    deltaReady();
+
+    void
     cancel();
+
+    bool
+    finished();
 
 private:
     void
@@ -129,16 +132,16 @@ private:
     pmDowncast() override;
 
     void
-    done();
+    trigger(ScopedLockType& peerSetLock);
 
     void
-    trigger();
+    tryAdvance(ScopedLockType& peerSetLock);
 
     LedgerReplayer& replayer_;
     TaskParameter parameter_;
     std::shared_ptr<SkipListAcquire> skipListAcquirer_;
-    std::shared_ptr<Ledger const> parent = {};
-    int deltaToBuild = -1;  // should not build until have parent
+    std::shared_ptr<Ledger const> parent_ = {};
+    int deltaToBuild = 0;  // should not build until have parent
     std::vector<std::shared_ptr<LedgerDeltaAcquire>> deltas_;
 
     friend class test::LedgerForwardReplay_test;

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -52,8 +52,7 @@ public:
         std::uint32_t totalLedgers;  // including the start and the finish
         // to be filled
         std::uint32_t finishSeq = 0;
-        std::vector<uint256> skipList =
-            {};  // including the start and the finish
+        std::vector<uint256> skipList = {};  // including the finishHash
         uint256 startHash = {};
         std::uint32_t startSeq = 0;
         bool full = false;
@@ -139,7 +138,7 @@ private:
     TaskParameter parameter_;
     std::shared_ptr<SkipListAcquire> skipListAcquirer_;
     std::shared_ptr<Ledger const> parent_ = {};
-    int deltaToBuild = 0;  // should not build until have parent
+    uint32_t deltaToBuild = 0;  // should not build until have parent
     std::vector<std::shared_ptr<LedgerDeltaAcquire>> deltas_;
 
     friend class test::LedgerForwardReplay_test;

--- a/src/ripple/app/ledger/LedgerReplayTask.h
+++ b/src/ripple/app/ledger/LedgerReplayTask.h
@@ -29,6 +29,15 @@
 
 namespace ripple {
 
+using namespace std::chrono_literals;
+// Timeout interval in milliseconds
+auto constexpr LEDGER_REPLAY_TIMEOUT = 250ms;
+
+enum {
+    LEDGER_REPLAY_NORM_TIMEOUTS = 4,
+    LEDGER_REPLAY_MAX_TIMEOUTS = 20,
+};
+
 class LedgerDeltaAcquire;
 class SkipListAcquire;
 
@@ -160,7 +169,7 @@ public:
         std::vector<ripple::uint256> const& data);
 
     void
-    tryAdvance(std::shared_ptr<Ledger const> const& ledger);
+    tryAdvance(std::optional<std::shared_ptr<Ledger const> const> ledger);
 
     TaskParameter&
     getTaskTaskParameter()

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -32,6 +32,7 @@
 
 namespace ripple {
 namespace test {
+class LedgerReplayClient;
 class LedgerForwardReplay_test;
 }  // namespace test
 
@@ -76,14 +77,14 @@ public:
     void
     removeLedgerDeltaAcquire(uint256 const& hash)
     {
-        std::lock_guard<std::mutex> lock(lock_);
+        std::unique_lock<std::recursive_mutex> lock(lock_);
         deltas_.erase(hash);
     }
 
     void
     removeSkipListAcquire(uint256 const& hash)
     {
-        std::lock_guard<std::mutex> lock(lock_);
+        std::unique_lock<std::recursive_mutex> lock(lock_);
         skipLists_.erase(hash);
     }
 
@@ -94,7 +95,7 @@ public:
     onStop() override;
 
 private:
-    mutable std::mutex lock_;
+    mutable std::recursive_mutex lock_;
     std::list<std::shared_ptr<LedgerReplayTask>> tasks_;
     hash_map<uint256, std::weak_ptr<LedgerDeltaAcquire>> deltas_;
     hash_map<uint256, std::weak_ptr<SkipListAcquire>> skipLists_;
@@ -102,6 +103,7 @@ private:
     std::unique_ptr<PeerSetBuilder> peerSetBuilder_;
     beast::Journal j_;
 
+    friend class test::LedgerReplayClient;
     friend class test::LedgerForwardReplay_test;
 };
 

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -51,22 +51,26 @@ public:
     createDeltas(std::shared_ptr<LedgerReplayTask> task);
 
     void
-    gotProofPath(std::shared_ptr<protocol::TMProofPathResponse> response);
+    gotSkipList(
+        LedgerInfo const& info,
+        std::shared_ptr<SHAMapItem const> const& data);
 
     void
-    gotReplayDelta(std::shared_ptr<protocol::TMReplayDeltaResponse> response);
+    gotReplayDelta(
+        LedgerInfo const& info,
+        std::map<std::uint32_t, std::shared_ptr<STTx const>>&& txns);
 
     void
     removeLedgerDeltaAcquire(uint256 const& hash)
     {
-        std::lock_guard<std::recursive_mutex> lock(lock_);
+        std::lock_guard<std::mutex> lock(lock_);
         deltas_.erase(hash);
     }
 
     void
     removeSkipListAcquire(uint256 const& hash)
     {
-        std::lock_guard<std::recursive_mutex> lock(lock_);
+        std::lock_guard<std::mutex> lock(lock_);
         skipLists_.erase(hash);
     }
 
@@ -75,7 +79,7 @@ private:
     clock_type& clock_;
     hash_map<uint256, std::weak_ptr<LedgerDeltaAcquire>> deltas_;
     hash_map<uint256, std::weak_ptr<SkipListAcquire>> skipLists_;
-    mutable std::recursive_mutex lock_;
+    mutable std::mutex lock_;
     beast::Journal j_;
 };
 

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -26,6 +26,7 @@
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/core/Stoppable.h>
 
+#include <list>
 #include <memory>
 #include <mutex>
 
@@ -51,7 +52,7 @@ public:
         Application& app,
         std::unique_ptr<PeerSetBuilder> peerSetBuilder,
         Stoppable& parent);
-    ~LedgerReplayer() = default;
+    ~LedgerReplayer();
 
     void
     replay(
@@ -87,18 +88,14 @@ public:
     }
 
     void
-    removeTask(std::shared_ptr<LedgerReplayTask> const& task)
-    {
-        std::lock_guard<std::mutex> lock(lock_);
-        tasks_.erase(task);
-    }
+    sweep();
 
     void
     onStop() override;
 
 private:
     mutable std::mutex lock_;
-    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
+    std::list<std::shared_ptr<LedgerReplayTask>> tasks_;
     hash_map<uint256, std::weak_ptr<LedgerDeltaAcquire>> deltas_;
     hash_map<uint256, std::weak_ptr<SkipListAcquire>> skipLists_;
     Application& app_;

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -1,0 +1,86 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_LEDGER_LEDGERFORWARDREPLAYER_H_INCLUDED
+#define RIPPLE_APP_LEDGER_LEDGERFORWARDREPLAYER_H_INCLUDED
+
+#include <ripple/app/ledger/LedgerReplayTask.h>
+//#include <ripple/beast/container/aged_map.h>
+//#include <ripple/core/Stoppable.h>
+#include <ripple/app/ledger/LedgerMaster.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/beast/utility/Journal.h>
+#include <memory>
+
+#include <mutex>
+namespace ripple {
+
+/**
+ * Manages the lifetime of ledger replay tasks.
+ */
+class LedgerReplayer  //: public Stoppable
+{
+public:
+    using clock_type = beast::abstract_clock<std::chrono::steady_clock>;
+
+    LedgerReplayer(Application& app, clock_type& clock);
+    // TODO ,                   Stoppable& parent);
+    ~LedgerReplayer() = default;
+
+    void
+    replay(LedgerReplayTask::TaskParameter&& parameter);
+    // TODO move in parameter?
+
+    void
+    createDeltas(std::shared_ptr<LedgerReplayTask> task);
+
+    void
+    gotProofPath(std::shared_ptr<protocol::TMProofPathResponse> response);
+
+    void
+    gotReplayDelta(std::shared_ptr<protocol::TMReplayDeltaResponse> response);
+
+    void
+    removeLedgerDeltaAcquire(uint256 const& hash)
+    {
+        std::lock_guard<std::recursive_mutex> lock(lock_);
+        deltas_.erase(hash);
+    }
+
+    void
+    removeSkipListAcquire(uint256 const& hash)
+    {
+        std::lock_guard<std::recursive_mutex> lock(lock_);
+        skipLists_.erase(hash);
+    }
+
+private:
+    Application& app_;
+    clock_type& clock_;
+    hash_map<uint256, std::weak_ptr<LedgerDeltaAcquire>> deltas_;
+    hash_map<uint256, std::weak_ptr<SkipListAcquire>> skipLists_;
+    mutable std::recursive_mutex lock_;
+    beast::Journal j_;
+};
+
+}  // namespace ripple
+
+#endif
+
+// TODO beast::aged_map<uint256, std::uint32_t> mRecentFailures;

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -81,10 +81,18 @@ public:
     }
 
     void
+    removeTask(std::shared_ptr<LedgerReplayTask> const& task)
+    {
+        std::lock_guard<std::mutex> lock(lock_);
+        tasks_.erase(task);
+    }
+
+    void
     onStop() override;
 
 private:
     mutable std::mutex lock_;
+    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
     hash_map<uint256, std::weak_ptr<LedgerDeltaAcquire>> deltas_;
     hash_map<uint256, std::weak_ptr<SkipListAcquire>> skipLists_;
     Application& app_;

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -45,7 +45,6 @@ public:
 
     void
     replay(LedgerReplayTask::TaskParameter&& parameter);
-    // TODO move in parameter?
 
     void
     createDeltas(std::shared_ptr<LedgerReplayTask> task);

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -81,10 +81,10 @@ private:
     hash_map<uint256, std::weak_ptr<SkipListAcquire>> skipLists_;
     mutable std::mutex lock_;
     beast::Journal j_;
+    // TODO retry of the failed ones should be delayed
+    // beast::aged_map<uint256, std::uint32_t> mRecentFailures;
 };
 
 }  // namespace ripple
 
 #endif
-
-// TODO beast::aged_map<uint256, std::uint32_t> mRecentFailures;

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -51,6 +51,7 @@ public:
 
     LedgerReplayer(
         Application& app,
+        InboundLedgers& inboundLedgers,
         std::unique_ptr<PeerSetBuilder> peerSetBuilder,
         Stoppable& parent);
     ~LedgerReplayer();
@@ -100,6 +101,7 @@ private:
     hash_map<uint256, std::weak_ptr<LedgerDeltaAcquire>> deltas_;
     hash_map<uint256, std::weak_ptr<SkipListAcquire>> skipLists_;
     Application& app_;
+    InboundLedgers& inboundLedgers_;
     std::unique_ptr<PeerSetBuilder> peerSetBuilder_;
     beast::Journal j_;
 

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -20,8 +20,8 @@
 #ifndef RIPPLE_APP_LEDGER_LEDGERFORWARDREPLAYER_H_INCLUDED
 #define RIPPLE_APP_LEDGER_LEDGERFORWARDREPLAYER_H_INCLUDED
 
-#include <ripple/app/ledger/LedgerReplayTask.h>
 #include <ripple/app/ledger/LedgerMaster.h>
+#include <ripple/app/ledger/LedgerReplayTask.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/core/Stoppable.h>
@@ -30,6 +30,9 @@
 #include <mutex>
 
 namespace ripple {
+namespace test {
+class LedgerForwardReplay_test;
+}  // namespace test
 
 /**
  * Manages the lifetime of ledger replay tasks.
@@ -89,7 +92,7 @@ private:
     std::unique_ptr<PeerSetBuilder> peerSetBuilder_;
     beast::Journal j_;
 
-    friend class LedgerForwardReplay_test;
+    friend class test::LedgerForwardReplay_test;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -40,7 +40,6 @@ class LedgerForwardReplay_test;
 class LedgerReplayer : public Stoppable
 {
 public:
-    using clock_type = beast::abstract_clock<std::chrono::steady_clock>;
 
     LedgerReplayer(
         Application& app,

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -17,8 +17,8 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_APP_LEDGER_LEDGERFORWARDREPLAYER_H_INCLUDED
-#define RIPPLE_APP_LEDGER_LEDGERFORWARDREPLAYER_H_INCLUDED
+#ifndef RIPPLE_APP_LEDGER_LEDGERREPLAYER_H_INCLUDED
+#define RIPPLE_APP_LEDGER_LEDGERREPLAYER_H_INCLUDED
 
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/ledger/LedgerReplayTask.h>
@@ -40,6 +40,12 @@ class LedgerForwardReplay_test;
 class LedgerReplayer : public Stoppable
 {
 public:
+    static auto constexpr TASK_TIMEOUT = 500ms;
+    static auto constexpr SUB_TASK_TIMEOUT = 250ms;
+    static int constexpr TASK_MAX_TIMEOUTS_MULTIPLIER = 2;
+    static int constexpr SUB_TASK_MAX_TIMEOUTS = 10;
+    static int constexpr MAX_TASKS = 10;
+    static int constexpr MAX_QUEUED_TASKS = 100;
 
     LedgerReplayer(
         Application& app,

--- a/src/ripple/app/ledger/LedgerReplayer.h
+++ b/src/ripple/app/ledger/LedgerReplayer.h
@@ -33,7 +33,6 @@
 namespace ripple {
 namespace test {
 class LedgerReplayClient;
-class LedgerForwardReplay_test;
 }  // namespace test
 
 /**
@@ -106,7 +105,6 @@ private:
     beast::Journal j_;
 
     friend class test::LedgerReplayClient;
-    friend class test::LedgerForwardReplay_test;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -78,7 +78,11 @@ InboundLedger::InboundLedger(
     Reason reason,
     clock_type& clock,
     std::unique_ptr<PeerSet> peerSet)
-    : TimeoutCounter(app, hash, ledgerAcquireTimeout, app.journal("InboundLedger"))
+    : TimeoutCounter(
+          app,
+          hash,
+          ledgerAcquireTimeout,
+          app.journal("InboundLedger"))
     , m_clock(clock)
     , mHaveHeader(false)
     , mHaveState(false)
@@ -164,7 +168,7 @@ InboundLedger::getPeerCount() const
 {
     std::size_t count = 0;
     mPeerSet->visitAddedPeers([this, &count](auto id) {
-        if( app_.overlay().findPeerByShortID(id) != nullptr)
+        if (app_.overlay().findPeerByShortID(id) != nullptr)
             ++count;
     });
     return count;
@@ -624,7 +628,7 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
 
                 auto packet =
                     std::make_shared<Message>(tmBH, protocol::mtGET_OBJECTS);
-                mPeerSet->visitAddedPeers([this, &packet](auto id){
+                mPeerSet->visitAddedPeers([this, &packet](auto id) {
                     if (auto p = app_.overlay().findPeerByShortID(id))
                     {
                         mByHash = false;
@@ -632,14 +636,15 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                     }
                 });
 
-//                for (auto id : mPeers)
-//                {
-//                    if (auto p = app_.overlay().findPeerByShortID(id))
-//                    {
-//                        mByHash = false;
-//                        p->send(packet);
-//                    }
-//                }
+                //                for (auto id : mPeers)
+                //                {
+                //                    if (auto p =
+                //                    app_.overlay().findPeerByShortID(id))
+                //                    {
+                //                        mByHash = false;
+                //                        p->send(packet);
+                //                    }
+                //                }
             }
             else
             {
@@ -662,7 +667,8 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             tmGL.set_ledgerseq(mSeq);
         JLOG(m_journal.trace()) << "Sending header request to "
                                 << (peer ? "selected peer" : "all peers");
-        //auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+        // auto packet = std::make_shared<Message>(tmGL,
+        // protocol::mtGET_LEDGER);
         mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
         return;
     }
@@ -700,9 +706,10 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             *tmGL.add_nodeids() = SHAMapNodeID().getRawString();
             JLOG(m_journal.trace()) << "Sending AS root request to "
                                     << (peer ? "selected peer" : "all peers");
-//            auto packet =
-//                std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
-//            sendRequest(packet, peer);
+            //            auto packet =
+            //                std::make_shared<Message>(tmGL,
+            //                protocol::mtGET_LEDGER);
+            //            sendRequest(packet, peer);
             mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
             return;
         }
@@ -748,10 +755,13 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                             << "Sending AS node request (" << nodes.size()
                             << ") to "
                             << (peer ? "selected peer" : "all peers");
-//                        auto packet = std::make_shared<Message>(
-//                            tmGL, protocol::mtGET_LEDGER);
-//                        sendRequest(packet, peer);
-                        mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
+                        //                        auto packet =
+                        //                        std::make_shared<Message>(
+                        //                            tmGL,
+                        //                            protocol::mtGET_LEDGER);
+                        //                        sendRequest(packet, peer);
+                        mPeerSet->sendRequest(
+                            tmGL, protocol::mtGET_LEDGER, peer);
                         return;
                     }
                     else
@@ -778,9 +788,10 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             *(tmGL.add_nodeids()) = SHAMapNodeID().getRawString();
             JLOG(m_journal.trace()) << "Sending TX root request to "
                                     << (peer ? "selected peer" : "all peers");
-//            auto packet =
-//                std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
-//            sendRequest(packet, peer);
+            //            auto packet =
+            //                std::make_shared<Message>(tmGL,
+            //                protocol::mtGET_LEDGER);
+            //            sendRequest(packet, peer);
             mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
             return;
         }
@@ -818,9 +829,10 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                     JLOG(m_journal.trace())
                         << "Sending TX node request (" << nodes.size()
                         << ") to " << (peer ? "selected peer" : "all peers");
-//                    auto packet =
-//                        std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
-//                    sendRequest(packet, peer);
+                    //                    auto packet =
+                    //                        std::make_shared<Message>(tmGL,
+                    //                        protocol::mtGET_LEDGER);
+                    //                    sendRequest(packet, peer);
                     mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
                     return;
                 }

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -635,16 +635,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                         p->send(packet);
                     }
                 });
-
-                //                for (auto id : mPeers)
-                //                {
-                //                    if (auto p =
-                //                    app_.overlay().findPeerByShortID(id))
-                //                    {
-                //                        mByHash = false;
-                //                        p->send(packet);
-                //                    }
-                //                }
             }
             else
             {
@@ -667,8 +657,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             tmGL.set_ledgerseq(mSeq);
         JLOG(m_journal.trace()) << "Sending header request to "
                                 << (peer ? "selected peer" : "all peers");
-        // auto packet = std::make_shared<Message>(tmGL,
-        // protocol::mtGET_LEDGER);
         mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
         return;
     }
@@ -706,10 +694,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             *tmGL.add_nodeids() = SHAMapNodeID().getRawString();
             JLOG(m_journal.trace()) << "Sending AS root request to "
                                     << (peer ? "selected peer" : "all peers");
-            //            auto packet =
-            //                std::make_shared<Message>(tmGL,
-            //                protocol::mtGET_LEDGER);
-            //            sendRequest(packet, peer);
             mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
             return;
         }
@@ -755,11 +739,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                             << "Sending AS node request (" << nodes.size()
                             << ") to "
                             << (peer ? "selected peer" : "all peers");
-                        //                        auto packet =
-                        //                        std::make_shared<Message>(
-                        //                            tmGL,
-                        //                            protocol::mtGET_LEDGER);
-                        //                        sendRequest(packet, peer);
                         mPeerSet->sendRequest(
                             tmGL, protocol::mtGET_LEDGER, peer);
                         return;
@@ -788,10 +767,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             *(tmGL.add_nodeids()) = SHAMapNodeID().getRawString();
             JLOG(m_journal.trace()) << "Sending TX root request to "
                                     << (peer ? "selected peer" : "all peers");
-            //            auto packet =
-            //                std::make_shared<Message>(tmGL,
-            //                protocol::mtGET_LEDGER);
-            //            sendRequest(packet, peer);
             mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
             return;
         }
@@ -829,10 +804,6 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                     JLOG(m_journal.trace())
                         << "Sending TX node request (" << nodes.size()
                         << ") to " << (peer ? "selected peer" : "all peers");
-                    //                    auto packet =
-                    //                        std::make_shared<Message>(tmGL,
-                    //                        protocol::mtGET_LEDGER);
-                    //                    sendRequest(packet, peer);
                     mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
                     return;
                 }

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -644,7 +644,8 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             tmGL.set_ledgerseq(mSeq);
         JLOG(m_journal.trace()) << "Sending header request to "
                                 << (peer ? "selected peer" : "all peers");
-        sendRequest(tmGL, peer);
+        auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+        sendRequest(packet, peer);
         return;
     }
 
@@ -681,7 +682,9 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             *tmGL.add_nodeids() = SHAMapNodeID().getRawString();
             JLOG(m_journal.trace()) << "Sending AS root request to "
                                     << (peer ? "selected peer" : "all peers");
-            sendRequest(tmGL, peer);
+            auto packet =
+                std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+            sendRequest(packet, peer);
             return;
         }
         else
@@ -726,7 +729,9 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                             << "Sending AS node request (" << nodes.size()
                             << ") to "
                             << (peer ? "selected peer" : "all peers");
-                        sendRequest(tmGL, peer);
+                        auto packet = std::make_shared<Message>(
+                            tmGL, protocol::mtGET_LEDGER);
+                        sendRequest(packet, peer);
                         return;
                     }
                     else
@@ -753,7 +758,9 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
             *(tmGL.add_nodeids()) = SHAMapNodeID().getRawString();
             JLOG(m_journal.trace()) << "Sending TX root request to "
                                     << (peer ? "selected peer" : "all peers");
-            sendRequest(tmGL, peer);
+            auto packet =
+                std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+            sendRequest(packet, peer);
             return;
         }
         else
@@ -790,7 +797,9 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
                     JLOG(m_journal.trace())
                         << "Sending TX node request (" << nodes.size()
                         << ") to " << (peer ? "selected peer" : "all peers");
-                    sendRequest(tmGL, peer);
+                    auto packet =
+                        std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+                    sendRequest(packet, peer);
                     return;
                 }
                 else

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -92,8 +92,12 @@ public:
             else
             {
                 inbound = std::make_shared<InboundLedger>(
-                    app_, hash, seq, reason, std::ref(m_clock),
-                    mPeerSetBuilder->build(app_));
+                    app_,
+                    hash,
+                    seq,
+                    reason,
+                    std::ref(m_clock),
+                    mPeerSetBuilder->build());
                 mLedgers.emplace(hash, inbound);
                 inbound->init(sl);
                 ++mCounter;
@@ -437,7 +441,8 @@ make_InboundLedgers(
     Stoppable& parent,
     beast::insight::Collector::ptr const& collector)
 {
-    return std::make_unique<InboundLedgersImp>(app, clock, parent, collector, make_PeerSetBuilder());
+    return std::make_unique<InboundLedgersImp>(
+        app, clock, parent, collector, make_PeerSetBuilder(app));
 }
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -52,7 +52,8 @@ public:
         Application& app,
         clock_type& clock,
         Stoppable& parent,
-        beast::insight::Collector::ptr const& collector)
+        beast::insight::Collector::ptr const& collector,
+        std::unique_ptr<PeerSetBuilder> peerSetBuilder)
         : Stoppable("InboundLedgers", parent)
         , app_(app)
         , fetchRate_(clock.now())
@@ -60,6 +61,7 @@ public:
         , m_clock(clock)
         , mRecentFailures(clock)
         , mCounter(collector->make_counter("ledger_fetches"))
+        , mPeerSetBuilder(std::move(peerSetBuilder))
     {
     }
 
@@ -90,7 +92,8 @@ public:
             else
             {
                 inbound = std::make_shared<InboundLedger>(
-                    app_, hash, seq, reason, std::ref(m_clock));
+                    app_, hash, seq, reason, std::ref(m_clock),
+                    mPeerSetBuilder->build(app_));
                 mLedgers.emplace(hash, inbound);
                 inbound->init(sl);
                 ++mCounter;
@@ -416,6 +419,8 @@ private:
     beast::aged_map<uint256, std::uint32_t> mRecentFailures;
 
     beast::insight::Counter mCounter;
+
+    std::unique_ptr<PeerSetBuilder> mPeerSetBuilder;
 };
 
 //------------------------------------------------------------------------------
@@ -432,7 +437,7 @@ make_InboundLedgers(
     Stoppable& parent,
     beast::insight::Collector::ptr const& collector)
 {
-    return std::make_unique<InboundLedgersImp>(app, clock, parent, collector);
+    return std::make_unique<InboundLedgersImp>(app, clock, parent, collector, make_PeerSetBuilder());
 }
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/InboundTransactions.cpp
+++ b/src/ripple/app/ledger/impl/InboundTransactions.cpp
@@ -67,12 +67,14 @@ public:
         Application& app,
         Stoppable& parent,
         beast::insight::Collector::ptr const& collector,
-        std::function<void(std::shared_ptr<SHAMap> const&, bool)> gotSet)
+        std::function<void(std::shared_ptr<SHAMap> const&, bool)> gotSet,
+        std::unique_ptr<PeerSetBuilder> peerSetBuilder)
         : Stoppable("InboundTransactions", parent)
         , app_(app)
         , m_seq(0)
         , m_zeroSet(m_map[uint256()])
         , m_gotSet(std::move(gotSet))
+        , m_peerSetBuilder(std::move(peerSetBuilder))
     {
         m_zeroSet.mSet = std::make_shared<SHAMap>(
             SHAMapType::TRANSACTION, uint256(), app_.getNodeFamily());
@@ -119,7 +121,8 @@ public:
             if (!acquire || isStopping())
                 return std::shared_ptr<SHAMap>();
 
-            ta = std::make_shared<TransactionAcquire>(app_, hash);
+            ta = std::make_shared<TransactionAcquire>(
+                app_, hash, m_peerSetBuilder->build(app_));
 
             auto& obj = m_map[hash];
             obj.mAcquire = ta;
@@ -254,6 +257,8 @@ private:
     InboundTransactionSet& m_zeroSet;
 
     std::function<void(std::shared_ptr<SHAMap> const&, bool)> m_gotSet;
+
+    std::unique_ptr<PeerSetBuilder> m_peerSetBuilder;
 };
 
 //------------------------------------------------------------------------------
@@ -268,7 +273,7 @@ make_InboundTransactions(
     std::function<void(std::shared_ptr<SHAMap> const&, bool)> gotSet)
 {
     return std::make_unique<InboundTransactionsImp>(
-        app, parent, collector, std::move(gotSet));
+        app, parent, collector, std::move(gotSet), make_PeerSetBuilder());
 }
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/InboundTransactions.cpp
+++ b/src/ripple/app/ledger/impl/InboundTransactions.cpp
@@ -122,7 +122,7 @@ public:
                 return std::shared_ptr<SHAMap>();
 
             ta = std::make_shared<TransactionAcquire>(
-                app_, hash, m_peerSetBuilder->build(app_));
+                app_, hash, m_peerSetBuilder->build());
 
             auto& obj = m_map[hash];
             obj.mAcquire = ta;
@@ -273,7 +273,7 @@ make_InboundTransactions(
     std::function<void(std::shared_ptr<SHAMap> const&, bool)> gotSet)
 {
     return std::make_unique<InboundTransactionsImp>(
-        app, parent, collector, std::move(gotSet), make_PeerSetBuilder());
+        app, parent, collector, std::move(gotSet), make_PeerSetBuilder(app));
 }
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
@@ -34,7 +34,6 @@ namespace ripple {
 
 LedgerDeltaAcquire::LedgerDeltaAcquire(
     Application& app,
-    LedgerReplayer& replayer,
     uint256 const& ledgerHash,
     std::uint32_t ledgerSeq,
     std::unique_ptr<PeerSet> peerSet)
@@ -43,17 +42,17 @@ LedgerDeltaAcquire::LedgerDeltaAcquire(
           ledgerHash,
           LedgerReplayer::SUB_TASK_TIMEOUT,
           app.journal("LedgerReplayDelta"))
-    , replayer_(replayer)
     , ledgerSeq_(ledgerSeq)
     , peerSet_(std::move(peerSet))
 {
     JLOG(m_journal.debug())
-        << "Acquire ledger " << mHash << " Seq " << ledgerSeq;
+        << "Delta ctor " << mHash << " Seq " << ledgerSeq;
 }
 
 LedgerDeltaAcquire::~LedgerDeltaAcquire()
 {
     JLOG(m_journal.trace()) << "Delta dtor " << mHash;
+    app_.getLedgerReplayer().removeLedgerDeltaAcquire(mHash);
 }
 
 void
@@ -72,7 +71,7 @@ LedgerDeltaAcquire::init(int numPeers)
             if (auto sptr = t.lock(); sptr)
                 sptr->deltaReady();
         }
-        stopReceive();
+        //stopReceive();
     }
     else
     {
@@ -129,7 +128,7 @@ LedgerDeltaAcquire::onTimer(bool progress, ScopedLockType& psl)
             if (auto sptr = t.lock(); sptr)
                 sptr->cancel();
         }
-        stopReceive();
+        //stopReceive();
     }
     else
     {
@@ -168,7 +167,7 @@ LedgerDeltaAcquire::processData(
             if (auto sptr = t.lock(); sptr)
                 sptr->deltaReady();
         }
-        stopReceive();
+        //stopReceive();
     }
 }
 
@@ -273,10 +272,10 @@ LedgerDeltaAcquire::onLedgerBuilt(std::optional<InboundLedger::Reason> reason)
     }
 }
 
-void
-LedgerDeltaAcquire::stopReceive()
-{
-    replayer_.removeLedgerDeltaAcquire(mHash);
-}
+//void
+//LedgerDeltaAcquire::stopReceive()
+//{
+//    app_.getLedgerReplayer().removeLedgerDeltaAcquire(mHash);
+//}
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
@@ -186,12 +186,13 @@ LedgerDeltaAcquire::tryBuild(std::shared_ptr<Ledger const> const& parent)
     if (mFailed || !mComplete || !replayTemp_)
         return {};
 
-    assert(parent->seq() + 1 == replayTemp_->seq() &&
-           parent->info().hash == replayTemp_->info().parentHash);
+    assert(
+        parent->seq() + 1 == replayTemp_->seq() &&
+        parent->info().hash == replayTemp_->info().parentHash);
     // build ledger
     LedgerReplay replayData(parent, replayTemp_, std::move(orderedTxns_));
     fullLedger_ = buildLedger(replayData, tapNONE, app_, m_journal);
-    if(fullLedger_ && fullLedger_->info().hash == mHash)
+    if (fullLedger_ && fullLedger_->info().hash == mHash)
     {
         JLOG(m_journal.info()) << "Built " << mHash;
         onLedgerBuilt();
@@ -199,7 +200,7 @@ LedgerDeltaAcquire::tryBuild(std::shared_ptr<Ledger const> const& parent)
     }
     else
     {
-        mFailed = true; // mComplete == true now
+        mFailed = true;  // mComplete == true now
         JLOG(m_journal.error())
             << "tryBuild failed " << mHash << " parent " << parent->info().hash;
         notifyTasks(sl);
@@ -264,7 +265,7 @@ LedgerDeltaAcquire::notifyTasks(ScopedLockType& psl)
     {
         if (auto sptr = t.lock(); sptr)
         {
-            if(mFailed)
+            if (mFailed)
                 sptr->cancel();
             else
                 sptr->deltaReady();

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
@@ -1,0 +1,219 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/BuildLedger.h>
+#include <ripple/app/ledger/InboundLedgers.h>
+#include <ripple/app/ledger/LedgerReplay.h>
+#include <ripple/app/ledger/LedgerReplayer.h>
+#include <ripple/app/ledger/impl/LedgerDeltaAcquire.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/overlay/Overlay.h>
+
+#include <memory>
+
+namespace ripple {
+
+using namespace std::chrono_literals;
+
+// Timeout interval in milliseconds
+auto constexpr ACQUIRE_TIMEOUT = 250ms;
+
+enum {
+    NORM_TIMEOUTS = 4,
+    MAX_TIMEOUTS = 20,
+};
+
+LedgerDeltaAcquire::LedgerDeltaAcquire(
+    Application& app,
+    uint256 const& ledgerHash,
+    std::uint32_t ledgerSeq)
+    : PeerSet(
+          app,
+          ledgerHash,
+          ACQUIRE_TIMEOUT,
+          app.journal("LedgerDeltaAcquire"))
+    , ledgerSeq_(ledgerSeq)
+{
+}
+
+LedgerDeltaAcquire::~LedgerDeltaAcquire()
+{
+    app_.getLedgerReplayer().removeLedgerDeltaAcquire(mHash);
+}
+
+void
+LedgerDeltaAcquire::init(int numPeers)
+{
+    ScopedLockType sl(mLock);
+    addPeers(numPeers);
+    setTimer();
+}
+
+void
+LedgerDeltaAcquire::queueJob()
+{
+    app_.getJobQueue().addJob(
+        jtREPLAY_DELTA_REQUEST,
+        "LedgerDeltaAcquire",
+        [ptr = shared_from_this()](Job&) { ptr->invokeOnTimer(); });
+}
+
+void
+LedgerDeltaAcquire::onTimer(bool progress, ScopedLockType& psl)
+{
+    if (mTimeouts > MAX_TIMEOUTS)
+    {
+        mFailed = true;
+        for (auto& t : tasks_)
+            t->subTaskFailed(LedgerReplayTask::SubTaskType::LEDGER_DELTA);
+        return;
+    }
+
+    addPeers(1);
+}
+
+std::weak_ptr<PeerSet>
+LedgerDeltaAcquire::pmDowncast()
+{
+    return shared_from_this();
+}
+
+void
+LedgerDeltaAcquire::trigger(std::shared_ptr<Peer> const& peer)
+{
+    if (mComplete)
+    {
+        // JLOG(m_journal.info()) << "trigger after complete";
+        return;
+    }
+    if (mFailed)
+    {
+        // JLOG(m_journal.info()) << "trigger after fail";
+        return;
+    }
+
+    if (!replay_)
+    {
+        JLOG(m_journal.trace())
+            << "LedgerDeltaAcquire::trigger " << (peer ? "havePeer" : "noPeer")
+            << " hash " << mHash;
+        protocol::TMReplayDeltaRequest request;
+        request.set_ledgerhash(mHash.data(), mHash.size());
+        auto packet =
+            std::make_shared<Message>(request, protocol::mtReplayDeltaRequest);
+        sendRequest(packet, peer);
+    }
+}
+
+void
+LedgerDeltaAcquire::processData(
+    LedgerInfo const& info,
+    std::map<std::uint32_t, std::shared_ptr<STTx const>>&& orderedTxns)
+{
+    // create LedgerReplay object
+    auto rp =
+        std::make_shared<Ledger>(info, app_.config(), app_.getNodeFamily());
+    if (rp)
+        return;
+
+    ScopedLockType sl(mLock);
+    if (mComplete)
+        return;
+    replay_ = rp;
+    mComplete = true;
+    JLOG(m_journal.debug()) << "LedgerDeltaAcquire received " << mHash;
+}
+
+std::shared_ptr<Ledger const>
+LedgerDeltaAcquire::tryBuild(std::shared_ptr<Ledger const> const& parent)
+{
+    ScopedLockType sl(mLock);
+
+    if (ledgerBuilt_)
+    {
+        return replay_;
+    }
+
+    if (mFailed)
+    {
+        return {};
+    }
+
+    if (!mComplete || !replay_)
+    {
+        return {};
+    }
+
+    // build ledger TODO jobQueue ??
+    assert(parent->info().hash == replay_->info().parentHash);
+    LedgerReplay replayData(parent, replay_, std::move(orderedTxns_));
+    auto const l = buildLedger(replayData, tapNONE, app_, m_journal);
+    if (!l)
+    {
+        JLOG(m_journal.error()) << "tryBuild failed";
+        orderedTxns_ = replayData.orderedTxns();
+        return {};
+    }
+    assert(mHash == l->info().hash);
+
+    replay_ = l;
+    ledgerBuilt_ = true;
+    onLedgerBuilt({});
+    return l;
+}
+
+void
+LedgerDeltaAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
+{
+    ScopedLockType sl(mLock);
+    auto r = tasks_.emplace(task);
+    assert(r.second);
+    auto reason = task->getTaskTaskParameter().reason;
+    if (reasons_.count(reason) == 0)
+    {
+        reasons_.emplace(reason);
+        if (ledgerBuilt_)
+            onLedgerBuilt(reason);
+    }
+    if (mFailed)
+        task->subTaskFailed(LedgerReplayTask::SubTaskType::LEDGER_DELTA);
+}
+
+void
+LedgerDeltaAcquire::onLedgerBuilt(std::optional<InboundLedger::Reason> reason)
+{
+    if (reason)
+    {
+        // TODO just for this reason
+    }
+    else
+    {
+        // TODO for all reasons in reasons_
+    }
+}
+
+void
+LedgerDeltaAcquire::addPeers(std::size_t limit)
+{
+    PeerSet::addPeers(limit, [this](auto peer) {
+        return peer->hasLedger(mHash, ledgerSeq_);
+    });
+}
+}  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
@@ -54,7 +54,7 @@ LedgerDeltaAcquire::LedgerDeltaAcquire(
 LedgerDeltaAcquire::~LedgerDeltaAcquire()
 {
     replayer_.removeLedgerDeltaAcquire(mHash);
-    JLOG(m_journal.trace()) << "remove myself " << mHash;
+    JLOG(m_journal.trace()) << "Delta dtor, remove myself " << mHash;
 }
 
 void
@@ -90,7 +90,8 @@ LedgerDeltaAcquire::addPeers(std::size_t limit)
                 << "Add a peer " << peer->id() << " for " << mHash;
             protocol::TMReplayDeltaRequest request;
             request.set_ledgerhash(mHash.data(), mHash.size());
-            peerSet_->sendRequest(request, protocol::mtReplayDeltaRequest, peer);
+            peerSet_->sendRequest(
+                request, protocol::mtReplayDeltaRequest, peer);
         });
 }
 
@@ -145,7 +146,7 @@ LedgerDeltaAcquire::processData(
         replay_ = rp;
         orderedTxns_ = std::move(orderedTxns);
         JLOG(m_journal.debug()) << "ready to replay " << mHash;
-        for(auto &t : tasks_)
+        for (auto& t : tasks_)
             t->tryAdvance({});
     }
 }
@@ -167,12 +168,12 @@ LedgerDeltaAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
         task->cancel();
 }
 
-void
-LedgerDeltaAcquire::removeTask(std::shared_ptr<LedgerReplayTask>const& task)
-{
-    ScopedLockType sl(mLock);
-    tasks_.erase(task);
-}
+// void
+// LedgerDeltaAcquire::removeTask(std::shared_ptr<LedgerReplayTask>const& task)
+//{
+//    ScopedLockType sl(mLock);
+//    tasks_.erase(task);
+//}
 
 std::shared_ptr<Ledger const>
 LedgerDeltaAcquire::tryBuild(std::shared_ptr<Ledger const> const& parent)

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
@@ -95,9 +95,11 @@ LedgerDeltaAcquire::addPeers(std::size_t limit)
 void
 LedgerDeltaAcquire::queueJob()
 {
+    std::weak_ptr<LedgerDeltaAcquire> wptr = shared_from_this();
     app_.getJobQueue().addJob(
-        jtREPLAY_DELTA, "LedgerDeltaAcquire", [ptr = shared_from_this()](Job&) {
-            ptr->invokeOnTimer();
+        jtREPLAY_DELTA, "LedgerDeltaAcquire", [wptr](Job&) {
+          if(auto sptr = wptr.lock(); sptr)
+              sptr->invokeOnTimer();
         });
 }
 

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
@@ -176,6 +176,7 @@ LedgerDeltaAcquire::tryBuild(std::shared_ptr<Ledger const> const& parent)
         return {};
 
     // build ledger
+    assert(parent->seq() + 1 == replay_->seq());
     assert(parent->info().hash == replay_->info().parentHash);
     LedgerReplay replayData(parent, replay_, std::move(orderedTxns_));
     auto const l = buildLedger(replayData, tapNONE, app_, m_journal);

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.cpp
@@ -130,8 +130,9 @@ LedgerDeltaAcquire::processData(
     std::map<std::uint32_t, std::shared_ptr<STTx const>>&& orderedTxns)
 {
     JLOG(m_journal.trace()) << "got data for " << mHash;
+    assert(info.seq == ledgerSeq_);
 
-    // create LedgerReplay object
+    // create a temp ledger for building a LedgerReplay object later
     if (auto rp =
             std::make_shared<Ledger>(info, app_.config(), app_.getNodeFamily());
         rp)

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -1,0 +1,107 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_LEDGER_LEDGERDELTAACQUIRE_H_INCLUDED
+#define RIPPLE_APP_LEDGER_LEDGERDELTAACQUIRE_H_INCLUDED
+
+#include <ripple/app/ledger/InboundLedger.h>
+#include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/overlay/PeerSet.h>
+#include <ripple/shamap/SHAMap.h>
+
+namespace ripple {
+
+class LedgerReplayTask;
+
+// A ledger delta (header and transactions) we are trying to acquire
+class LedgerDeltaAcquire final
+    : public PeerSet,
+      public std::enable_shared_from_this<LedgerDeltaAcquire>,
+      public CountedObject<LedgerDeltaAcquire>
+{
+public:
+    static char const*
+    getCountedObjectName()
+    {
+        return "LedgerDeltaAcquire";
+    }
+
+    using pointer = std::shared_ptr<LedgerDeltaAcquire>;
+
+public:
+    LedgerDeltaAcquire(
+        Application& app,
+        uint256 const& ledgerHash,
+        std::uint32_t ledgerSeq);
+
+    ~LedgerDeltaAcquire();
+
+    void
+    init(int numPeers);
+
+    void
+    processData(
+        LedgerInfo const& info,
+        std::map<std::uint32_t, std::shared_ptr<STTx const>>&& orderedTxns);
+
+    std::shared_ptr<Ledger const>
+    tryBuild(std::shared_ptr<Ledger const> const& parent);
+
+    void
+    addTask(std::shared_ptr<LedgerReplayTask>& task);
+
+private:
+    std::uint32_t ledgerSeq_;
+    std::shared_ptr<Ledger const> replay_;
+    std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns_;
+    // TODO call tryAdvance() for all in tasks_ ??
+    // std::shared_ptr<Ledger const> parent_;
+    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
+    std::set<InboundLedger::Reason> reasons_;
+    bool ledgerBuilt_ = false;
+
+    void
+    queueJob() override;
+
+    void
+    onTimer(bool progress, ScopedLockType& peerSetLock) override;
+
+    void
+    onPeerAdded(std::shared_ptr<Peer> const& peer) override
+    {
+        trigger(peer);
+    }
+
+    std::weak_ptr<PeerSet>
+    pmDowncast() override;
+
+    void
+    addPeers(std::size_t limit);
+
+    void
+    trigger(std::shared_ptr<Peer> const&);
+
+    void
+    onLedgerBuilt(std::optional<InboundLedger::Reason> reason);
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -29,12 +29,15 @@
 namespace ripple {
 
 class LedgerReplayTask;
+namespace test {
+class LedgerForwardReplay_test;
+}  // namespace test
 
 // A ledger delta (header and transactions) we are trying to acquire
 class LedgerDeltaAcquire final
     : public TimeoutCounter,
       public std::enable_shared_from_this<LedgerDeltaAcquire>,
-      public CountedObject<LedgerDeltaAcquire> //TODO needed??
+      public CountedObject<LedgerDeltaAcquire>  // TODO needed??
 {
 public:
     static char const*
@@ -66,8 +69,8 @@ public:
     void
     addTask(std::shared_ptr<LedgerReplayTask>& task);
 
-    void
-    removeTask(std::shared_ptr<LedgerReplayTask>const& task);
+    //    void
+    //    removeTask(std::shared_ptr<LedgerReplayTask>const& task);
 
 private:
     void
@@ -95,7 +98,7 @@ private:
     bool ledgerBuilt_ = false;
 
     friend class LedgerReplayTask;
-    friend class LedgerForwardReplay_test;
+    friend class test::LedgerForwardReplay_test;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -90,7 +90,7 @@ private:
     std::unique_ptr<PeerSet> peerSet_;
     std::shared_ptr<Ledger const> replay_;
     std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns_;
-    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
+    std::list<std::weak_ptr<LedgerReplayTask>> tasks_;
     std::set<InboundLedger::Reason> reasons_;
     bool ledgerBuilt_ = false;
 

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -69,9 +69,6 @@ public:
     void
     addTask(std::shared_ptr<LedgerReplayTask>& task);
 
-    //    void
-    //    removeTask(std::shared_ptr<LedgerReplayTask>const& task);
-
 private:
     void
     queueJob() override;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -50,7 +50,7 @@ public:
         uint256 const& ledgerHash,
         std::uint32_t ledgerSeq);
 
-    ~LedgerDeltaAcquire();
+    ~LedgerDeltaAcquire() override;
 
     void
     init(int numPeers);

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -86,15 +86,15 @@ private:
     trigger(std::size_t limit, ScopedLockType& psl);
 
     void
-    onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
+    onLedgerBuilt(
+        ScopedLockType& psl,
+        std::optional<InboundLedger::Reason> reason = {});
 
     void
     notifyTasks(ScopedLockType& psl);
 
     void
-    notifyTask(
-        ScopedLockType& psl,
-        std::shared_ptr<LedgerReplayTask>& task);
+    notifyTask(ScopedLockType& psl, std::shared_ptr<LedgerReplayTask>& task);
 
     InboundLedgers& inboundLedgers_;
     LedgerReplayer& replayer_;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -86,21 +86,16 @@ private:
     void
     onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
 
-    enum class DataStatus
-    {
-        dataReady,
-        failed
-    };
     void
-    notifyTasks(DataStatus status, ScopedLockType& psl);
+    notifyTasks(ScopedLockType& psl);
 
     std::uint32_t const ledgerSeq_;
     std::unique_ptr<PeerSet> peerSet_;
-    std::shared_ptr<Ledger const> replay_;
+    std::shared_ptr<Ledger const> replayTemp_ = {};
+    std::shared_ptr<Ledger const> fullLedger_ = {};
     std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns_;
     std::list<std::weak_ptr<LedgerReplayTask>> tasks_;
     std::set<InboundLedger::Reason> reasons_;
-    bool ledgerBuilt_ = false;
 
     friend class LedgerReplayTask; // for assert only
     friend class test::LedgerForwardReplay_test;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -26,6 +26,8 @@
 #include <ripple/overlay/PeerSet.h>
 #include <ripple/shamap/SHAMap.h>
 
+#include <list>
+
 namespace ripple {
 
 class LedgerReplayTask;
@@ -84,6 +86,9 @@ private:
 
     void
     onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
+
+    void
+    stopReceive();
 
     LedgerReplayer& replayer_;
     std::uint32_t const ledgerSeq_;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -32,7 +32,7 @@ namespace ripple {
 
 class LedgerReplayTask;
 namespace test {
-class LedgerForwardReplay_test;
+class LedgerReplayClient;
 }  // namespace test
 
 // A ledger delta (header and transactions) we are trying to acquire
@@ -51,6 +51,7 @@ public:
     LedgerDeltaAcquire(
         Application& app,
         InboundLedgers& inboundLedgers,
+        LedgerReplayer& replayer,
         uint256 const& ledgerHash,
         std::uint32_t ledgerSeq,
         std::unique_ptr<PeerSet> peerSet);
@@ -91,6 +92,7 @@ private:
     notifyTasks(ScopedLockType& psl);
 
     InboundLedgers& inboundLedgers_;
+    LedgerReplayer& replayer_;
     std::uint32_t const ledgerSeq_;
     std::unique_ptr<PeerSet> peerSet_;
     std::shared_ptr<Ledger const> replayTemp_ = {};
@@ -101,7 +103,7 @@ private:
     bool fallBack_ = false;
 
     friend class LedgerReplayTask;  // for assert only
-    friend class test::LedgerForwardReplay_test;
+    friend class test::LedgerReplayClient;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -37,7 +37,7 @@ class LedgerForwardReplay_test;
 class LedgerDeltaAcquire final
     : public TimeoutCounter,
       public std::enable_shared_from_this<LedgerDeltaAcquire>,
-      public CountedObject<LedgerDeltaAcquire>  // TODO needed??
+      public CountedObject<LedgerDeltaAcquire>
 {
 public:
     static char const*
@@ -86,7 +86,7 @@ private:
     onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
 
     LedgerReplayer& replayer_;
-    std::uint32_t ledgerSeq_;
+    std::uint32_t const ledgerSeq_;
     std::unique_ptr<PeerSet> peerSet_;
     std::shared_ptr<Ledger const> replay_;
     std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns_;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -50,6 +50,7 @@ public:
 
     LedgerDeltaAcquire(
         Application& app,
+        InboundLedgers& inboundLedgers,
         uint256 const& ledgerHash,
         std::uint32_t ledgerSeq,
         std::unique_ptr<PeerSet> peerSet);
@@ -81,7 +82,7 @@ private:
     pmDowncast() override;
 
     void
-    addPeers(std::size_t limit);
+    trigger(std::size_t limit, ScopedLockType& psl);
 
     void
     onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
@@ -89,6 +90,7 @@ private:
     void
     notifyTasks(ScopedLockType& psl);
 
+    InboundLedgers& inboundLedgers_;
     std::uint32_t const ledgerSeq_;
     std::unique_ptr<PeerSet> peerSet_;
     std::shared_ptr<Ledger const> replayTemp_ = {};
@@ -96,6 +98,7 @@ private:
     std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns_;
     std::list<std::weak_ptr<LedgerReplayTask>> tasks_;
     std::set<InboundLedger::Reason> reasons_;
+    bool fallBack_ = false;
 
     friend class LedgerReplayTask;  // for assert only
     friend class test::LedgerForwardReplay_test;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -45,7 +45,6 @@ public:
 
     using pointer = std::shared_ptr<LedgerDeltaAcquire>;
 
-public:
     LedgerDeltaAcquire(
         Application& app,
         uint256 const& ledgerHash,
@@ -68,15 +67,6 @@ public:
     addTask(std::shared_ptr<LedgerReplayTask>& task);
 
 private:
-    std::uint32_t ledgerSeq_;
-    std::shared_ptr<Ledger const> replay_;
-    std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns_;
-    // TODO call tryAdvance() for all in tasks_ ??
-    // std::shared_ptr<Ledger const> parent_;
-    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
-    std::set<InboundLedger::Reason> reasons_;
-    bool ledgerBuilt_ = false;
-
     void
     queueJob() override;
 
@@ -84,10 +74,7 @@ private:
     onTimer(bool progress, ScopedLockType& peerSetLock) override;
 
     void
-    onPeerAdded(std::shared_ptr<Peer> const& peer) override
-    {
-        trigger(peer);
-    }
+    onPeerAdded(std::shared_ptr<Peer> const& peer) override;
 
     std::weak_ptr<PeerSet>
     pmDowncast() override;
@@ -96,10 +83,16 @@ private:
     addPeers(std::size_t limit);
 
     void
-    trigger(std::shared_ptr<Peer> const&);
+    onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
 
-    void
-    onLedgerBuilt(std::optional<InboundLedger::Reason> reason);
+    std::uint32_t ledgerSeq_;
+    std::shared_ptr<Ledger const> replay_;
+    std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns_;
+    // TODO call tryAdvance() for all in tasks_ ??
+    // std::shared_ptr<Ledger const> parent_;
+    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
+    std::set<InboundLedger::Reason> reasons_;
+    bool ledgerBuilt_ = false;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -93,6 +93,8 @@ private:
     hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
     std::set<InboundLedger::Reason> reasons_;
     bool ledgerBuilt_ = false;
+
+    friend class LedgerReplayTask;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -86,9 +86,14 @@ private:
     void
     onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
 
-//    void
-//    stopReceive();
-//
+    enum class DataStatus
+    {
+        dataReady,
+        failed
+    };
+    void
+    notifyTasks(DataStatus status, ScopedLockType& psl);
+
     std::uint32_t const ledgerSeq_;
     std::unique_ptr<PeerSet> peerSet_;
     std::shared_ptr<Ledger const> replay_;
@@ -97,7 +102,7 @@ private:
     std::set<InboundLedger::Reason> reasons_;
     bool ledgerBuilt_ = false;
 
-    friend class LedgerReplayTask;
+    friend class LedgerReplayTask; // for assert only
     friend class test::LedgerForwardReplay_test;
 };
 

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -50,7 +50,6 @@ public:
 
     LedgerDeltaAcquire(
         Application& app,
-        LedgerReplayer& replayer,
         uint256 const& ledgerHash,
         std::uint32_t ledgerSeq,
         std::unique_ptr<PeerSet> peerSet);
@@ -87,10 +86,9 @@ private:
     void
     onLedgerBuilt(std::optional<InboundLedger::Reason> reason = {});
 
-    void
-    stopReceive();
-
-    LedgerReplayer& replayer_;
+//    void
+//    stopReceive();
+//
     std::uint32_t const ledgerSeq_;
     std::unique_ptr<PeerSet> peerSet_;
     std::shared_ptr<Ledger const> replay_;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -91,6 +91,11 @@ private:
     void
     notifyTasks(ScopedLockType& psl);
 
+    void
+    notifyTask(
+        ScopedLockType& psl,
+        std::shared_ptr<LedgerReplayTask>& task);
+
     InboundLedgers& inboundLedgers_;
     LedgerReplayer& replayer_;
     std::uint32_t const ledgerSeq_;

--- a/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
+++ b/src/ripple/app/ledger/impl/LedgerDeltaAcquire.h
@@ -97,7 +97,7 @@ private:
     std::list<std::weak_ptr<LedgerReplayTask>> tasks_;
     std::set<InboundLedger::Reason> reasons_;
 
-    friend class LedgerReplayTask; // for assert only
+    friend class LedgerReplayTask;  // for assert only
     friend class test::LedgerForwardReplay_test;
 };
 

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1293,7 +1293,7 @@ LedgerMaster::findNewLedgersToPublish(
 
     {
         // TODO remove, force a replay for test
-        //        if (app_.config().LEDGER_REPLAY_ENABLE)
+        //        if (app_.config().LEDGER_REPLAY)
         //        {
         //            static bool called_once = false;
         //            if (!called_once)
@@ -1375,7 +1375,7 @@ LedgerMaster::findNewLedgersToPublish(
                 ledger = mLedgerHistory.getLedgerByHash(*hash);
             }
 
-            if (!app_.config().LEDGER_REPLAY_ENABLE)
+            if (!app_.config().LEDGER_REPLAY)
             {
                 // Can we try to acquire the ledger we need?
                 if (!ledger && (++acqCount < ledger_fetch_size_))
@@ -1401,7 +1401,7 @@ LedgerMaster::findNewLedgersToPublish(
             << "Exception while trying to find ledgers to publish.";
     }
 
-    if (app_.config().LEDGER_REPLAY_ENABLE)
+    if (app_.config().LEDGER_REPLAY)
     {
         /* Narrow down the gap of ledgers, and try to replay them.
          * When replaying a ledger gap, if the local node has

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1293,18 +1293,21 @@ LedgerMaster::findNewLedgersToPublish(
 
     {
         // TODO remove, force a replay for test
-//        static bool called_once = false;
-//        if (!called_once)
+//        if (app_.config().LEDGER_REPLAY_ENABLE)
 //        {
-//            called_once = true;
-//            LedgerReplayTask::TaskParameter p(
-//                InboundLedger::Reason::GENERIC,
-//                mValidLedger.get()->info().hash, 50);
-//            JLOG(m_journal.debug())
-//                << "LFR end with " << mValidLedger.get()->info().seq << " "
-//                << mValidLedger.get()->info().hash << " back "
-//                << p.ledgersToBuild << " ledgers";
-//            app_.getLedgerReplayer().replay(std::move(p));
+//            static bool called_once = false;
+//            if (!called_once)
+//            {
+//                called_once = true;
+//                LedgerReplayTask::TaskParameter p(
+//                    InboundLedger::Reason::GENERIC,
+//                    mValidLedger.get()->info().hash, 5);
+//                JLOG(m_journal.debug())
+//                    << "LFR end with " << mValidLedger.get()->info().seq << " "
+//                    << mValidLedger.get()->info().hash << " back "
+//                    << p.totalLedgers << " ledgers";
+//                app_.getLedgerReplayer().replay(std::move(p));
+//            }
 //        }
     }
 

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1293,22 +1293,23 @@ LedgerMaster::findNewLedgersToPublish(
 
     {
         // TODO remove, force a replay for test
-//        if (app_.config().LEDGER_REPLAY_ENABLE)
-//        {
-//            static bool called_once = false;
-//            if (!called_once)
-//            {
-//                called_once = true;
-//                std::uint32_t totalLedgers = 5;
-//                JLOG(m_journal.debug())
-//                    << "LFR end with " << mValidLedger.get()->info().seq << " "
-//                    << mValidLedger.get()->info().hash << " back "
-//                    << totalLedgers << " ledgers";
-//                app_.getLedgerReplayer().replay(
-//                    InboundLedger::Reason::GENERIC,
-//                    mValidLedger.get()->info().hash, totalLedgers);
-//            }
-//        }
+        //        if (app_.config().LEDGER_REPLAY_ENABLE)
+        //        {
+        //            static bool called_once = false;
+        //            if (!called_once)
+        //            {
+        //                called_once = true;
+        //                std::uint32_t totalLedgers = 5;
+        //                JLOG(m_journal.debug())
+        //                    << "LFR end with " <<
+        //                    mValidLedger.get()->info().seq << " "
+        //                    << mValidLedger.get()->info().hash << " back "
+        //                    << totalLedgers << " ledgers";
+        //                app_.getLedgerReplayer().replay(
+        //                    InboundLedger::Reason::GENERIC,
+        //                    mValidLedger.get()->info().hash, totalLedgers);
+        //            }
+        //        }
     }
 
     if (!mPubLedger)

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1391,13 +1391,7 @@ LedgerMaster::findNewLedgersToPublish(
                 break;
         }
         LedgerReplayTask::TaskParameter p{
-            InboundLedger::Reason::GENERIC,
-            child->info().hash,
-            startHash,
-            0,
-            0,
-            0,
-            {}};
+            InboundLedger::Reason::GENERIC, child->info().hash, startHash};
         JLOG(m_journal.debug())
             << "Ask ledger replay from " << child->info().seq << " "
             << child->info().hash << " to " << ret.back()->info().seq << ""

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -20,7 +20,6 @@
 #include <ripple/app/consensus/RCLValidations.h>
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/ledger/LedgerMaster.h>
-#include <ripple/app/ledger/LedgerReplayTask.h>
 #include <ripple/app/ledger/LedgerReplayer.h>
 #include <ripple/app/ledger/OpenLedger.h>
 #include <ripple/app/ledger/OrderBookDB.h>
@@ -1421,18 +1420,18 @@ LedgerMaster::findNewLedgersToPublish(
             }
             else
             {
-                JLOG(m_journal.debug())
-                    << "Ask ledger replay from seq=" << startLedger->info().seq
-                    << ", " << startLedger->info().hash
-                    << " to seq=" << finishLedger->info().seq << ", "
-                    << finishLedger->info().hash;
-                app_.getLedgerReplayer().replay(
-                    InboundLedger::Reason::GENERIC,
-                    finishLedger->info().hash,
-                    finishLedger->seq() - startLedger->seq() + 1);
                 break;
             }
         }
+        JLOG(m_journal.debug())
+            << "Ledger replay (Publish) from seq=" << startLedger->info().seq
+            << ", " << startLedger->info().hash
+            << " to seq=" << finishLedger->info().seq << ", "
+            << finishLedger->info().hash;
+        app_.getLedgerReplayer().replay(
+            InboundLedger::Reason::GENERIC,
+            finishLedger->info().hash,
+            finishLedger->seq() - startLedger->seq() + 1);
     }
 
     return ret;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1398,6 +1398,10 @@ LedgerMaster::findNewLedgersToPublish(
             0,
             0,
             {}};
+        JLOG(m_journal.debug())
+            << "Ask ledger replay from " << child->info().seq << " "
+            << child->info().hash << " to " << ret.back()->info().seq << ""
+            << ret.back()->info().hash;
         app_.getLedgerReplayer().replay(std::move(p));
     }
     return ret;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1413,10 +1413,12 @@ LedgerMaster::findNewLedgersToPublish(
         auto finishLedger = valLedger;
         while (startLedger->seq() + 1 < finishLedger->seq())
         {
-            auto const parent =
-                mLedgerHistory.getLedgerByHash(finishLedger->info().parentHash);
-            if (parent)
+            if (auto const parent = mLedgerHistory.getLedgerByHash(
+                    finishLedger->info().parentHash);
+                parent)
+            {
                 finishLedger = parent;
+            }
             else
             {
                 JLOG(m_journal.debug())

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1297,10 +1297,9 @@ LedgerMaster::findNewLedgersToPublish(
 //        if (!called_once)
 //        {
 //            called_once = true;
-//            LedgerReplayTask::TaskParameter p{
+//            LedgerReplayTask::TaskParameter p(
 //                InboundLedger::Reason::GENERIC,
-//                mValidLedger.get()->info().hash};
-//            p.ledgersToBuild = 50;
+//                mValidLedger.get()->info().hash, 50);
 //            JLOG(m_journal.debug())
 //                << "LFR end with " << mValidLedger.get()->info().seq << " "
 //                << mValidLedger.get()->info().hash << " back "
@@ -1400,7 +1399,7 @@ LedgerMaster::findNewLedgersToPublish(
     {
         auto const& startLedger = ret.empty() ? mPubLedger : ret.back();
         auto finishLedger = valLedger;
-        while (startLedger->info().seq + 1 < finishLedger->info().seq)
+        while (startLedger->seq() + 1 < finishLedger->seq())
         {
             auto const parent =
                 mLedgerHistory.getLedgerByHash(finishLedger->info().parentHash);
@@ -1408,10 +1407,10 @@ LedgerMaster::findNewLedgersToPublish(
                 finishLedger = parent;
             else
             {
-                LedgerReplayTask::TaskParameter p{
+                LedgerReplayTask::TaskParameter p(
                     InboundLedger::Reason::GENERIC,
                     finishLedger->info().hash,
-                    startLedger->info().hash};
+                    finishLedger->seq() - startLedger->seq() + 1);
 
                 JLOG(m_journal.debug())
                     << "Ask ledger replay from " << startLedger->info().seq

--- a/src/ripple/app/ledger/impl/LedgerReplay.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplay.cpp
@@ -35,4 +35,14 @@ LedgerReplay::LedgerReplay(
     }
 }
 
+LedgerReplay::LedgerReplay(
+    std::shared_ptr<Ledger const> parent,
+    std::shared_ptr<Ledger const> replay,
+    std::map<std::uint32_t, std::shared_ptr<STTx const>>&& orderedTxns)
+    : parent_{std::move(parent)}
+    , replay_{std::move(replay)}
+    , orderedTxns_{std::move(orderedTxns)}
+{
+}
+
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
@@ -26,10 +26,8 @@
 
 namespace ripple {
 LedgerReplayMsgHandler::LedgerReplayMsgHandler(
-    Application& app,
-    LedgerReplayer& replayer)
+    Application& app)
     : app_(app)
-    , replayer_(replayer)
     , journal_(app.journal("LedgerReplayMsgHandler"))
 {
 }
@@ -170,7 +168,7 @@ LedgerReplayMsgHandler::processProofPathResponse(
         return;
     }
 
-    replayer_.gotSkipList(info, item);
+    app_.getLedgerReplayer().gotSkipList(info, item);
 }
 
 protocol::TMReplayDeltaResponse
@@ -285,7 +283,7 @@ LedgerReplayMsgHandler::processReplayDeltaResponse(
         return;
     }
 
-    replayer_.gotReplayDelta(info, std::move(orderedTxns));
+    app_.getLedgerReplayer().gotReplayDelta(info, std::move(orderedTxns));
 }
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
@@ -68,9 +68,9 @@ LedgerReplayMsgHandler::processProofPathRequest(
     auto const path = [&]() -> std::optional<std::vector<Blob>> {
         switch (packet.type())
         {
-            case protocol::lmAS_NODE:
+            case protocol::lmAS:
                 return ledger->stateMap().getProofPath(key);
-            case protocol::lmTX_NODE:
+            case protocol::lmTX:
                 return ledger->txMap().getProofPath(key);
             default:
                 // should not be here
@@ -114,7 +114,7 @@ LedgerReplayMsgHandler::processProofPathResponse(
         return false;
     }
 
-    if (reply.type() != protocol::lmAS_NODE)
+    if (reply.type() != protocol::lmAS)
     {
         JLOG(journal_.debug())
             << "Bad message: we only support the state ShaMap for now";

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
@@ -25,8 +25,12 @@
 #include <memory>
 
 namespace ripple {
-LedgerReplayMsgHandler::LedgerReplayMsgHandler(Application& app)
-    : app_(app), journal_(app.journal("LedgerReplayMsgHandler"))
+LedgerReplayMsgHandler::LedgerReplayMsgHandler(
+    Application& app,
+    LedgerReplayer& replayer)
+    : app_(app)
+    , replayer_(replayer)
+    , journal_(app.journal("LedgerReplayMsgHandler"))
 {
 }
 
@@ -166,7 +170,7 @@ LedgerReplayMsgHandler::processProofPathResponse(
         return false;
     }
 
-    app_.getLedgerReplayer().gotSkipList(info, item);
+    replayer_.gotSkipList(info, item);
     return true;
 }
 
@@ -281,7 +285,7 @@ LedgerReplayMsgHandler::processReplayDeltaResponse(
         return false;
     }
 
-    app_.getLedgerReplayer().gotReplayDelta(info, std::move(orderedTxns));
+    replayer_.gotReplayDelta(info, std::move(orderedTxns));
     return true;
 }
 

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
@@ -25,10 +25,8 @@
 #include <memory>
 
 namespace ripple {
-LedgerReplayMsgHandler::LedgerReplayMsgHandler(
-    Application& app)
-    : app_(app)
-    , journal_(app.journal("LedgerReplayMsgHandler"))
+LedgerReplayMsgHandler::LedgerReplayMsgHandler(Application& app)
+    : app_(app), journal_(app.journal("LedgerReplayMsgHandler"))
 {
 }
 
@@ -85,7 +83,7 @@ LedgerReplayMsgHandler::processProofPathRequest(
         return reply;
     }
 
-    // pack header, code copied from getLedger()
+    // pack header
     Serializer nData(128);
     addRaw(ledger->info(), nData);
     reply.set_ledgerheader(nData.getDataPtr(), nData.getLength());
@@ -134,9 +132,10 @@ LedgerReplayMsgHandler::processProofPathResponse(
     uint256 key(reply.key());
     if (key != keylet::skip().key)
     {
-        JLOG(journal_.trace()) << "Bad message: we only support the short "
-                                  "skip list for now. Key in reply "
-                               << key;
+        JLOG(journal_.trace())
+            << "Bad message: we only support the short skip list for now. "
+               "Key in reply "
+            << key;
         return;
     }
 

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.cpp
@@ -1,0 +1,291 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/LedgerMaster.h>
+#include <ripple/app/ledger/LedgerReplayer.h>
+#include <ripple/app/ledger/impl/LedgerReplayMsgHandler.h>
+#include <ripple/app/main/Application.h>
+
+#include <memory>
+
+namespace ripple {
+LedgerReplayMsgHandler::LedgerReplayMsgHandler(
+    Application& app,
+    LedgerReplayer& replayer)
+    : app_(app)
+    , replayer_(replayer)
+    , journal_(app.journal("LedgerReplayMsgHandler"))
+{
+}
+
+protocol::TMProofPathResponse
+LedgerReplayMsgHandler::processProofPathRequest(
+    std::shared_ptr<protocol::TMProofPathRequest> const& msg)
+{
+    protocol::TMProofPathRequest& packet = *msg;
+    protocol::TMProofPathResponse reply;
+
+    if (!packet.has_key() || !packet.has_ledgerhash() || !packet.has_type() ||
+        packet.ledgerhash().size() != uint256::size() ||
+        packet.key().size() != uint256::size() ||
+        !protocol::TMLedgerMapType_IsValid(packet.type()))
+    {
+        JLOG(journal_.debug()) << "getProofPath: Invalid request";
+        reply.set_error(protocol::TMReplyError::reBAD_REQUEST);
+        return reply;
+    }
+    reply.set_key(packet.key());
+    reply.set_ledgerhash(packet.ledgerhash());
+    reply.set_type(packet.type());
+
+    uint256 const key{packet.key()};
+    uint256 const ledgerHash{packet.ledgerhash()};
+    auto ledger = app_.getLedgerMaster().getLedgerByHash(ledgerHash);
+    if (!ledger || !ledger->isImmutable())
+    {
+        JLOG(journal_.debug())
+            << "getProofPath: Don't have ledger " << ledgerHash;
+        reply.set_error(protocol::TMReplyError::reNO_LEDGER);
+        return reply;
+    }
+
+    auto const path = [&]() -> std::optional<std::vector<Blob>> {
+        switch (packet.type())
+        {
+            case protocol::lmAS_NODE:
+                return ledger->stateMap().getProofPath(key);
+            case protocol::lmTX_NODE:
+                return ledger->txMap().getProofPath(key);
+            default:
+                // should not be here
+                // because already tested with TMLedgerMapType_IsValid()
+                return {};
+        }
+    }();
+
+    if (!path)
+    {
+        JLOG(journal_.debug()) << "getProofPath: Don't have the node " << key
+                               << " of ledger " << ledgerHash;
+        reply.set_error(protocol::TMReplyError::reNO_NODE);
+        return reply;
+    }
+
+    // pack header, code copied from getLedger()
+    Serializer nData(128);
+    addRaw(ledger->info(), nData);
+    reply.set_ledgerheader(nData.getDataPtr(), nData.getLength());
+    // pack path
+    for (auto const& b : *path)
+        reply.add_path(b.data(), b.size());
+
+    JLOG(journal_.debug()) << "getProofPath for the node " << key
+                           << " of ledger " << ledgerHash << " path length "
+                           << path->size();
+    return reply;
+}
+
+void
+LedgerReplayMsgHandler::processProofPathResponse(
+    std::shared_ptr<protocol::TMProofPathResponse> const& msg)
+{
+    JLOG(journal_.trace()) << "onMessage, TMProofPathResponse";
+    protocol::TMProofPathResponse& reply = *msg;
+    if (reply.has_error() || !reply.has_key() || !reply.has_ledgerhash() ||
+        !reply.has_type() || !reply.has_ledgerheader() ||
+        reply.path_size() == 0)
+    {
+        JLOG(journal_.trace()) << "Bad message: Error reply";
+        return;
+    }
+
+    if (reply.type() != protocol::lmAS_NODE)
+    {
+        JLOG(journal_.trace())
+            << "Bad message: we only support the state ShaMap for now";
+        return;
+    }
+
+    // deserialize the header
+    auto info = deserializeHeader(
+        {reply.ledgerheader().data(), reply.ledgerheader().size()});
+    uint256 replyHash(reply.ledgerhash());
+    if (calculateLedgerHash(info) != replyHash)
+    {
+        JLOG(journal_.trace()) << "Bad message: Hash mismatch";
+        return;
+    }
+    info.hash = replyHash;
+
+    uint256 key(reply.key());
+    if (key != keylet::skip().key)
+    {
+        JLOG(journal_.trace()) << "Bad message: we only support the short "
+                                  "skip list for now. Key in reply "
+                               << key;
+        return;
+    }
+
+    // verify the skip list
+    std::vector<Blob> path;
+    path.reserve(reply.path_size());
+    for (int i = 0; i < reply.path_size(); ++i)
+    {
+        path.emplace_back(reply.path(i).begin(), reply.path(i).end());
+    }
+
+    if (!SHAMap::verifyProofPath(info.accountHash, key, path))
+    {
+        JLOG(journal_.trace()) << "Bad message: Proof path verify failed";
+        return;
+    }
+
+    // deserialize the SHAMapItem
+    auto node = SHAMapAbstractNode::makeFromWire(makeSlice(path.front()));
+    if (!node || !node->isLeaf())
+    {
+        JLOG(journal_.trace()) << "Bad message: Cannot deserialize";
+        return;
+    }
+    auto item = static_cast<SHAMapTreeNode*>(node.get())->peekItem();
+    if (!item)
+    {
+        JLOG(journal_.trace()) << "Bad message: Cannot get ShaMapItem";
+        return;
+    }
+
+    replayer_.gotSkipList(info, item);
+}
+
+protocol::TMReplayDeltaResponse
+LedgerReplayMsgHandler::processReplayDeltaRequest(
+    std::shared_ptr<protocol::TMReplayDeltaRequest> const& msg)
+{
+    protocol::TMReplayDeltaRequest& packet = *msg;
+    protocol::TMReplayDeltaResponse reply;
+
+    if (!packet.has_ledgerhash() ||
+        packet.ledgerhash().size() != uint256::size())
+    {
+        JLOG(journal_.debug()) << "getReplayDelta: Invalid request";
+        reply.set_error(protocol::TMReplyError::reBAD_REQUEST);
+        return reply;
+    }
+    reply.set_ledgerhash(packet.ledgerhash());
+
+    uint256 const ledgerHash{packet.ledgerhash()};
+    auto ledger = app_.getLedgerMaster().getLedgerByHash(ledgerHash);
+    if (!ledger || !ledger->isImmutable())
+    {
+        JLOG(journal_.debug())
+            << "getReplayDelta: Don't have ledger " << ledgerHash;
+        reply.set_error(protocol::TMReplyError::reNO_LEDGER);
+        return reply;
+    }
+
+    // pack header
+    Serializer nData(128);
+    addRaw(ledger->info(), nData);
+    reply.set_ledgerheader(nData.getDataPtr(), nData.getLength());
+    // pack transactions
+    auto const& txMap = ledger->txMap();
+    txMap.visitLeaves([&](std::shared_ptr<SHAMapItem const> const& txNode) {
+        reply.add_transaction(txNode->data(), txNode->size());
+    });
+
+    JLOG(journal_.debug()) << "getReplayDelta for ledger " << ledgerHash
+                           << " txMap hash " << txMap.getHash().as_uint256();
+    return reply;
+}
+
+void
+LedgerReplayMsgHandler::processReplayDeltaResponse(
+    std::shared_ptr<protocol::TMReplayDeltaResponse> const& msg)
+{
+    JLOG(journal_.trace()) << "onMessage, TMReplayDeltaResponse";
+    protocol::TMReplayDeltaResponse& reply = *msg;
+    if (reply.has_error() || !reply.has_ledgerheader())
+    {
+        JLOG(journal_.trace()) << "Bad message: Error reply";
+        return;
+    }
+
+    auto info = deserializeHeader(
+        {reply.ledgerheader().data(), reply.ledgerheader().size()});
+    uint256 replyHash(reply.ledgerhash());
+    if (calculateLedgerHash(info) != replyHash)
+    {
+        JLOG(journal_.trace()) << "Bad message: Hash mismatch";
+        return;
+    }
+    info.hash = replyHash;
+
+    auto numTxns = reply.transaction_size();
+    std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns;
+    SHAMap txMap(SHAMapType::TRANSACTION, app_.getNodeFamily());
+    try
+    {
+        for (int i = 0; i < numTxns; ++i)
+        {
+            // deserialize:
+            // -- TxShaMapItem for building a ShaMap for verification
+            // -- Tx
+            // -- TxMetaData for Tx ordering
+            Serializer shaMapItemData(
+                reply.transaction(i).data(), reply.transaction(i).size());
+
+            SerialIter txMetaSit(makeSlice(reply.transaction(i)));
+            SerialIter txSit(txMetaSit.getSlice(txMetaSit.getVLDataLength()));
+            SerialIter metaSit(txMetaSit.getSlice(txMetaSit.getVLDataLength()));
+
+            auto tx = std::make_shared<STTx const>(txSit);
+            if (!tx)
+            {
+                JLOG(journal_.trace()) << "Bad message: Cannot deserialize";
+                return;
+            }
+            auto tid = tx->getTransactionID();
+            STObject meta(metaSit, sfMetadata);
+            orderedTxns.emplace(meta[sfTransactionIndex], std::move(tx));
+
+            auto item = std::make_shared<SHAMapItem const>(
+                tid, std::move(shaMapItemData));
+            if (!item || !txMap.addGiveItem(std::move(item), true, true))
+            {
+                JLOG(journal_.trace()) << "Bad message: Cannot deserialize";
+                return;
+            }
+        }
+    }
+    catch (std::exception const&)
+    {
+        JLOG(journal_.trace()) << "Bad message: Cannot deserialize";
+        return;
+    }
+
+    if (txMap.getHash().as_uint256() != info.txHash)
+    {
+        JLOG(journal_.trace()) << "Bad message: Transactions verify failed";
+        return;
+    }
+
+    replayer_.gotReplayDelta(info, std::move(orderedTxns));
+}
+
+}  // namespace ripple

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
@@ -25,6 +25,7 @@
 
 namespace ripple {
 class Application;
+class LedgerReplayer;
 
 class LedgerReplayMsgHandler final
 {
@@ -32,18 +33,36 @@ public:
     LedgerReplayMsgHandler(Application& app, LedgerReplayer& replayer);
     ~LedgerReplayMsgHandler() = default;
 
+    /**
+     * Process TMProofPathRequest and return TMProofPathResponse
+     * @note check has_error() and error() of the response for error
+     */
     protocol::TMProofPathResponse
     processProofPathRequest(
         std::shared_ptr<protocol::TMProofPathRequest> const& msg);
 
+    /**
+     * Process TMProofPathResponse
+     * @return false if the response message has bad format or bad data;
+     *         true otherwise
+     */
     bool
     processProofPathResponse(
         std::shared_ptr<protocol::TMProofPathResponse> const& msg);
 
+    /**
+     * Process TMReplayDeltaRequest and return TMReplayDeltaResponse
+     * @note check has_error() and error() of the response for error
+     */
     protocol::TMReplayDeltaResponse
     processReplayDeltaRequest(
         std::shared_ptr<protocol::TMReplayDeltaRequest> const& msg);
 
+    /**
+     * Process TMReplayDeltaResponse
+     * @return false if the response message has bad format or bad data;
+     *         true otherwise
+     */
     bool
     processReplayDeltaResponse(
         std::shared_ptr<protocol::TMReplayDeltaResponse> const& msg);

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
@@ -36,7 +36,7 @@ public:
     processProofPathRequest(
         std::shared_ptr<protocol::TMProofPathRequest> const& msg);
 
-    void
+    bool
     processProofPathResponse(
         std::shared_ptr<protocol::TMProofPathResponse> const& msg);
 
@@ -44,7 +44,7 @@ public:
     processReplayDeltaRequest(
         std::shared_ptr<protocol::TMReplayDeltaRequest> const& msg);
 
-    void
+    bool
     processReplayDeltaResponse(
         std::shared_ptr<protocol::TMReplayDeltaResponse> const& msg);
 

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
@@ -29,7 +29,7 @@ class Application;
 class LedgerReplayMsgHandler final
 {
 public:
-    LedgerReplayMsgHandler(Application& app, LedgerReplayer& replayer);
+    LedgerReplayMsgHandler(Application& app);
     ~LedgerReplayMsgHandler() = default;
 
     protocol::TMProofPathResponse
@@ -50,7 +50,6 @@ public:
 
 private:
     Application& app_;
-    LedgerReplayer& replayer_;
     beast::Journal journal_;
 };
 

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_LEDGER_LEDGERREPLAYMSGHANDLER_H_INCLUDED
+#define RIPPLE_APP_LEDGER_LEDGERREPLAYMSGHANDLER_H_INCLUDED
+
+#include <ripple/beast/utility/Journal.h>
+#include <ripple/protocol/messages.h>
+
+namespace ripple {
+class Application;
+
+class LedgerReplayMsgHandler final
+{
+public:
+    LedgerReplayMsgHandler(Application& app, LedgerReplayer& replayer);
+    ~LedgerReplayMsgHandler() = default;
+
+    protocol::TMProofPathResponse
+    processProofPathRequest(
+        std::shared_ptr<protocol::TMProofPathRequest> const& msg);
+
+    void
+    processProofPathResponse(
+        std::shared_ptr<protocol::TMProofPathResponse> const& msg);
+
+    protocol::TMReplayDeltaResponse
+    processReplayDeltaRequest(
+        std::shared_ptr<protocol::TMReplayDeltaRequest> const& msg);
+
+    void
+    processReplayDeltaResponse(
+        std::shared_ptr<protocol::TMReplayDeltaResponse> const& msg);
+
+private:
+    Application& app_;
+    LedgerReplayer& replayer_;
+    beast::Journal journal_;
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
+++ b/src/ripple/app/ledger/impl/LedgerReplayMsgHandler.h
@@ -29,7 +29,7 @@ class Application;
 class LedgerReplayMsgHandler final
 {
 public:
-    LedgerReplayMsgHandler(Application& app);
+    LedgerReplayMsgHandler(Application& app, LedgerReplayer& replayer);
     ~LedgerReplayMsgHandler() = default;
 
     protocol::TMProofPathResponse
@@ -50,6 +50,7 @@ public:
 
 private:
     Application& app_;
+    LedgerReplayer& replayer_;
     beast::Journal journal_;
 };
 

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -42,6 +42,11 @@ LedgerReplayTask::LedgerReplayTask(
 {
 }
 
+LedgerReplayTask::~LedgerReplayTask()
+{
+    JLOG(m_journal.debug()) << "Task dtor " << mHash;
+}
+
 void
 LedgerReplayTask::init()
 {
@@ -58,11 +63,11 @@ LedgerReplayTask::trigger()
 
     if (parameter_.startHash.isNonZero())
     {
-        //if (ledgers_.empty())
-        if(!parent)
+        // if (ledgers_.empty())
+        if (!parent)
         {
-            auto l = app_.getLedgerMaster().getLedgerByHash(
-                parameter_.startHash);
+            auto l =
+                app_.getLedgerMaster().getLedgerByHash(parameter_.startHash);
             if (!l)
             {
                 l = app_.getInboundLedgers().acquire(
@@ -73,7 +78,8 @@ LedgerReplayTask::trigger()
             if (l)
             {
                 JLOG(m_journal.trace())
-                    << "Got start ledger " << parameter_.startHash << " for " << mHash;
+                    << "Got start ledger " << parameter_.startHash << " for "
+                    << mHash;
                 tryAdvance(l);
             }
         }
@@ -136,14 +142,14 @@ LedgerReplayTask::updateSkipList(
 void
 LedgerReplayTask::done()
 {
-    auto me = shared_from_this();
-    skipListAcquirer_->removeTask(me);
-    skipListAcquirer_ = nullptr;//TODO make sure no access after this point
-    for(auto & delta : deltas_)
-    {
-        delta->removeTask(me);
-    }
-    deltas_.clear();
+    //    auto me = shared_from_this();
+    //    skipListAcquirer_->removeTask(me);
+    skipListAcquirer_ = nullptr;  // TODO make sure no access after this point
+    //    for(auto & delta : deltas_)
+    //    {
+    //        //delta->removeTask(me);
+    //    }
+    //    deltas_.clear();
 
     if (mFailed)
     {
@@ -183,7 +189,7 @@ LedgerReplayTask::tryAdvance(
             return;
     }
 
-    if(deltaToBuild >= 0)
+    if (deltaToBuild >= 0)
     {
         while (deltaToBuild < deltas_.size())
         {

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -219,7 +219,7 @@ LedgerReplayTask::onTimer(bool progress, ScopedLockType& psl)
         parameter_.totalLedgers * LedgerReplayer::TASK_MAX_TIMEOUTS_MULTIPLIER)
     {
         mFailed = true;
-        JLOG(m_journal.warn())
+        JLOG(m_journal.debug())
             << "LedgerReplayTask Failed, too many timeouts " << mHash;
     }
     else

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -126,8 +126,8 @@ LedgerReplayTask::trigger(ScopedLockType& peerSetLock)
 void
 LedgerReplayTask::deltaReady(uint256 const& deltaHash)
 {
-    JLOG(m_journal.trace()) << "Delta " << deltaHash <<
-        " ready for task " << mHash;
+    JLOG(m_journal.trace())
+        << "Delta " << deltaHash << " ready for task " << mHash;
     ScopedLockType sl(mLock);
     tryAdvance(sl);
 }
@@ -137,9 +137,9 @@ LedgerReplayTask::tryAdvance(ScopedLockType& peerSetLock)
 {
     JLOG(m_journal.trace())
         << "tryAdvance task " << mHash
-        << (parameter_.full? ", full parameter" : ", waiting to fill parameter")
-        << ", deltaIndex=" << deltaToBuild
-        << ", totalDeltas=" << deltas_.size()
+        << (parameter_.full ? ", full parameter"
+                            : ", waiting to fill parameter")
+        << ", deltaIndex=" << deltaToBuild << ", totalDeltas=" << deltas_.size()
         << ", parent " << (parent_ ? parent_->info().hash : uint256());
 
     bool shouldTry = !isDone() && parent_ && parameter_.full &&

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -132,9 +132,11 @@ LedgerReplayTask::trigger()
 void
 LedgerReplayTask::queueJob()
 {
+    std::weak_ptr<LedgerReplayTask> wptr = shared_from_this();
     app_.getJobQueue().addJob(
-        jtREPLAY_TASK, "LedgerReplayTask", [ptr = shared_from_this()](Job&) {
-            ptr->invokeOnTimer();
+        jtREPLAY_TASK, "LedgerReplayTask", [wptr](Job&) {
+          if(auto sptr = wptr.lock(); sptr)
+                sptr->invokeOnTimer();
         });
 }
 

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -72,6 +72,7 @@ LedgerReplayTask::TaskParameter::canMergeInto(TaskParameter const& existingTask)
 
 LedgerReplayTask::LedgerReplayTask(
     Application& app,
+    InboundLedgers& inboundLedgers,
     std::shared_ptr<SkipListAcquire>& skipListAcquirer,
     TaskParameter&& parameter)
     : TimeoutCounter(
@@ -79,6 +80,7 @@ LedgerReplayTask::LedgerReplayTask(
           parameter.finishHash,
           LedgerReplayer::TASK_TIMEOUT,
           app.journal("LedgerReplayTask"))
+    , inboundLedgers_(inboundLedgers)
     , parameter_(parameter)
     , skipListAcquirer_(skipListAcquirer)
 {
@@ -112,7 +114,7 @@ LedgerReplayTask::trigger(ScopedLockType& peerSetLock)
         parent_ = app_.getLedgerMaster().getLedgerByHash(parameter_.startHash);
         if (!parent_)
         {
-            parent_ = app_.getInboundLedgers().acquire(
+            parent_ = inboundLedgers_.acquire(
                 parameter_.startHash,
                 parameter_.startSeq,
                 InboundLedger::Reason::GENERIC);

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -72,7 +72,6 @@ LedgerReplayTask::TaskParameter::canMergeInto(TaskParameter const& existingTask)
 
 LedgerReplayTask::LedgerReplayTask(
     Application& app,
-    LedgerReplayer& replayer,
     std::shared_ptr<SkipListAcquire>& skipListAcquirer,
     TaskParameter&& parameter)
     : TimeoutCounter(
@@ -80,10 +79,10 @@ LedgerReplayTask::LedgerReplayTask(
           parameter.finishHash,
           LedgerReplayer::TASK_TIMEOUT,
           app.journal("LedgerReplayTask"))
-    , replayer_(replayer)
     , parameter_(parameter)
     , skipListAcquirer_(skipListAcquirer)
 {
+    JLOG(m_journal.trace()) << "Task ctor " << mHash;
 }
 
 LedgerReplayTask::~LedgerReplayTask()
@@ -193,7 +192,7 @@ LedgerReplayTask::updateSkipList(
         }
     }
 
-    replayer_.createDeltas(shared_from_this());
+    app_.getLedgerReplayer().createDeltas(shared_from_this());
 }
 
 void

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -124,9 +124,10 @@ LedgerReplayTask::trigger(ScopedLockType& peerSetLock)
 }
 
 void
-LedgerReplayTask::deltaReady()
+LedgerReplayTask::deltaReady(uint256 const& deltaHash)
 {
-    JLOG(m_journal.trace()) << "A delta ready for task " << mHash;
+    JLOG(m_journal.trace()) << "Delta " << deltaHash <<
+        " ready for task " << mHash;
     ScopedLockType sl(mLock);
     tryAdvance(sl);
 }
@@ -135,8 +136,11 @@ void
 LedgerReplayTask::tryAdvance(ScopedLockType& peerSetLock)
 {
     JLOG(m_journal.trace())
-        << "tryAdvance task " << mHash << " deltaIndex=" << deltaToBuild
-        << " totalDeltas=" << deltas_.size();
+        << "tryAdvance task " << mHash
+        << (parameter_.full? ", full parameter" : ", waiting to fill parameter")
+        << ", deltaIndex=" << deltaToBuild
+        << ", totalDeltas=" << deltas_.size()
+        << ", parent " << (parent_ ? parent_->info().hash : uint256());
 
     bool shouldTry = !isDone() && parent_ && parameter_.full &&
         parameter_.totalLedgers - 1 == deltas_.size();

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -30,9 +30,7 @@ LedgerReplayTask::TaskParameter::TaskParameter(
     InboundLedger::Reason r,
     uint256 const& finishLedgerHash,
     std::uint32_t totalNumLedgers)
-    : reason(r)
-    , finishHash(finishLedgerHash)
-    , totalLedgers(totalNumLedgers)
+    : reason(r), finishHash(finishLedgerHash), totalLedgers(totalNumLedgers)
 {
 }
 
@@ -122,8 +120,8 @@ LedgerReplayTask::trigger(ScopedLockType& peerSetLock)
         if (parent_)
         {
             JLOG(m_journal.trace())
-                << "Got start ledger " << parameter_.startHash
-                << " for task " << mHash;
+                << "Got start ledger " << parameter_.startHash << " for task "
+                << mHash;
         }
     }
 
@@ -146,7 +144,7 @@ LedgerReplayTask::tryAdvance(ScopedLockType& peerSetLock)
         << " totalDeltas=" << deltas_.size();
 
     bool shouldTry = !isDone() && parent_ && parameter_.full &&
-                     parameter_.totalLedgers - 1 == deltas_.size();
+        parameter_.totalLedgers - 1 == deltas_.size();
     if (!shouldTry)
         return;
 

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -187,10 +187,7 @@ LedgerReplayTask::done()
         JLOG(m_journal.info()) << "LedgerReplayTask Completed " << mHash;
     }
 
-    // if this skipListAcquirer is not used by other tasks,
-    // destruct this skipListAcquirer, this task,
-    // and deltas if not used by other tasks
-    skipListAcquirer_ = nullptr;
+    replayer_.removeTask(shared_from_this());
 }
 
 void

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -1,0 +1,258 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/InboundLedgers.h>
+#include <ripple/app/ledger/LedgerReplayTask.h>
+#include <ripple/app/ledger/LedgerReplayer.h>
+#include <ripple/app/ledger/impl/LedgerDeltaAcquire.h>
+#include <ripple/app/ledger/impl/SkipListAcquire.h>
+#include <ripple/core/JobQueue.h>
+
+namespace ripple {
+
+using namespace std::chrono_literals;
+// Timeout interval in milliseconds
+auto constexpr ACQUIRE_TIMEOUT = 250ms;
+
+enum {
+    NORM_TIMEOUTS = 4,
+    MAX_TIMEOUTS = 20,
+};
+
+LedgerReplayTask::LedgerReplayTask(
+    Application& app,
+    std::shared_ptr<SkipListAcquire>& skipListAcquirer,
+    TaskParameter&& parameter)
+    : PeerSet(
+          app,
+          parameter.finishLedgerHash,
+          ACQUIRE_TIMEOUT,
+          app.journal("LedgerReplayTask"))
+    , parameter_(parameter)
+    , skipListAcquirer_(skipListAcquirer)
+{
+}
+
+void
+LedgerReplayTask::queueJob()
+{
+    app_.getJobQueue().addJob(
+        jtREPLAY_TASK, "LedgerReplayTask", [ptr = shared_from_this()](Job&) {
+            ptr->invokeOnTimer();
+        });
+}
+
+void
+LedgerReplayTask::onTimer(bool progress, ScopedLockType& psl)
+{
+    if (isDone())
+        return;
+
+    if (mTimeouts > MAX_TIMEOUTS)
+    {
+        mFailed = true;
+        done();
+        return;
+    }
+
+    trigger();
+}
+
+std::weak_ptr<PeerSet>
+LedgerReplayTask::pmDowncast()
+{
+    return shared_from_this();
+}
+
+void
+LedgerReplayTask::updateSkipList(
+    uint256 const& hash,
+    std::uint32_t seq,
+    std::vector<ripple::uint256> const& data)
+{
+    {
+        ScopedLockType sl(mLock);
+        if (!parameter_.update(hash, seq, data))
+            mFailed = true;
+    }
+
+    app_.getLedgerReplayer().createDeltas(shared_from_this());
+}
+
+void
+LedgerReplayTask::trigger()
+{
+    if (mComplete)
+    {
+        JLOG(m_journal.info()) << "trigger after complete";
+        return;
+    }
+    if (mFailed)
+    {
+        JLOG(m_journal.info()) << "trigger after fail";
+        return;
+    }
+
+    if (ledgers_.empty())  // nextSeqToBuild_ == parameter_.startLedgerSeq)
+    {
+        auto l = app_.getInboundLedgers().acquire(
+            parameter_.startLedgerHash,
+            parameter_.startLedgerSeq,
+            InboundLedger::Reason::GENERIC);
+        if (l)
+        {
+            tryAdvance(l);
+        }
+        else
+        {
+            setTimer();
+        }
+    }
+}
+
+void
+LedgerReplayTask::done()
+{
+    skipListAcquirer_ = nullptr;
+    ledgers_.clear();
+    deltas_.clear();
+    if (mFailed)
+    {
+        JLOG(m_journal.warn()) << "Failed";
+    }
+    if (mComplete)
+    {
+        JLOG(m_journal.info()) << "Completed";
+    }
+}
+
+void
+LedgerReplayTask::tryAdvance(std::shared_ptr<Ledger const> const& ledger)
+{
+    if (ledgers_.empty())
+    {
+        if (ledger->info().hash == parameter_.startLedgerHash)
+            ledgers_.emplace_back(ledger);
+        else
+            return;
+    }
+    else
+    {
+        if (ledger->info().parentHash == ledgers_.back()->info().hash)
+            ledgers_.emplace_back(ledger);
+        else
+            return;
+    }
+
+    while (ledgers_.size() <= deltas_.size())
+    {
+        auto l = deltas_[ledgers_.size() - 1]->tryBuild(ledgers_.back());
+        if (l)
+            ledgers_.emplace_back(l);
+        else
+            break;
+    }
+
+    if (ledgers_.size() == deltas_.size() + 1)
+    {
+        mComplete = true;
+        done();
+    }
+}
+
+void
+LedgerReplayTask::subTaskFailed(SubTaskType type)
+{
+    mFailed = true;
+    //    JLOG(m_journal.warn()) << "Failed due to " << type;
+    done();
+}
+
+}  // namespace ripple
+
+// TODO useful for build txMap to verify Txns in Delta responses
+// SHAMapAddNode
+// LedgerReplayTask::takeNodes(
+//    const std::list<SHAMapNodeID>& nodeIDs,
+//    const std::list<Blob>& data,
+//    std::shared_ptr<Peer> const& peer)
+//{
+//    ScopedLockType sl(mLock);
+//
+//    if (mComplete)
+//    {
+//        JLOG(m_journal.trace()) << "TX set complete";
+//        return SHAMapAddNode();
+//    }
+//
+//    if (mFailed)
+//    {
+//        JLOG(m_journal.trace()) << "TX set failed";
+//        return SHAMapAddNode();
+//    }
+//
+//    try
+//    {
+//        if (nodeIDs.empty())
+//            return SHAMapAddNode::invalid();
+//
+//        std::list<SHAMapNodeID>::const_iterator nodeIDit = nodeIDs.begin();
+//        std::list<Blob>::const_iterator nodeDatait = data.begin();
+//        ConsensusTransSetSF sf(app_, app_.getTempNodeCache());
+//
+//        while (nodeIDit != nodeIDs.end())
+//        {
+//            if (nodeIDit->isRoot())
+//            {
+//                if (mHaveRoot)
+//                    JLOG(m_journal.debug())
+//                        << "Got root TXS node, already have it";
+//                else if (!mMap->addRootNode(
+//                                  SHAMapHash{mHash},
+//                                  makeSlice(*nodeDatait),
+//                                  nullptr)
+//                              .isGood())
+//                {
+//                    JLOG(m_journal.warn()) << "TX acquire got bad root node";
+//                }
+//                else
+//                    mHaveRoot = true;
+//            }
+//            else if (!mMap->addKnownNode(*nodeIDit, makeSlice(*nodeDatait),
+//            &sf)
+//                          .isGood())
+//            {
+//                JLOG(m_journal.warn()) << "TX acquire got bad non-root node";
+//                return SHAMapAddNode::invalid();
+//            }
+//
+//            ++nodeIDit;
+//            ++nodeDatait;
+//        }
+//
+//        trigger(peer);
+//        mProgress = true;
+//        return SHAMapAddNode::useful();
+//    }
+//    catch (std::exception const&)
+//    {
+//        JLOG(m_journal.error()) << "Peer sends us junky transaction node
+//        data"; return SHAMapAddNode::invalid();
+//    }
+//}

--- a/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayTask.cpp
@@ -56,23 +56,15 @@ LedgerReplayTask::TaskParameter::update(
 bool
 LedgerReplayTask::TaskParameter::canMergeInto(TaskParameter const& existingTask)
 {
-    if (full)
-    {
-        return reason == existingTask.reason &&
-            startSeq >= existingTask.startSeq &&
-            finishSeq <= existingTask.finishSeq;
-    }
-    else
-    {
-        return reason == existingTask.reason &&
-            finishHash == existingTask.finishHash &&
-            totalLedgers == existingTask.totalLedgers;
-    }
+    return reason == existingTask.reason &&
+        finishHash == existingTask.finishHash &&
+        totalLedgers <= existingTask.totalLedgers;
 }
 
 LedgerReplayTask::LedgerReplayTask(
     Application& app,
     InboundLedgers& inboundLedgers,
+    LedgerReplayer& replayer,
     std::shared_ptr<SkipListAcquire>& skipListAcquirer,
     TaskParameter&& parameter)
     : TimeoutCounter(
@@ -81,6 +73,7 @@ LedgerReplayTask::LedgerReplayTask(
           LedgerReplayer::TASK_TIMEOUT,
           app.journal("LedgerReplayTask"))
     , inboundLedgers_(inboundLedgers)
+    , replayer_(replayer)
     , parameter_(parameter)
     , skipListAcquirer_(skipListAcquirer)
 {
@@ -189,7 +182,7 @@ LedgerReplayTask::updateSkipList(
         }
     }
 
-    app_.getLedgerReplayer().createDeltas(shared_from_this());
+    replayer_.createDeltas(shared_from_this());
 }
 
 void

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -1,0 +1,268 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/InboundLedgers.h>
+#include <ripple/app/ledger/LedgerReplayer.h>
+#include <ripple/app/ledger/impl/LedgerDeltaAcquire.h>
+#include <ripple/app/ledger/impl/SkipListAcquire.h>
+#include <ripple/core/JobQueue.h>
+
+namespace ripple {
+
+LedgerReplayer::LedgerReplayer(Application& app, clock_type& clock)
+    : app_(app), clock_(clock), j_(app.journal("LedgerReplayer"))
+{
+}
+
+void
+LedgerReplayer::replay(LedgerReplayTask::TaskParameter&& parameter)
+{
+    if (!parameter.isValid())
+    {
+        JLOG(j_.warn()) << "LedgerReplayer: bad parameter";
+        return;
+    }
+
+    bool needInit = false;
+    std::shared_ptr<SkipListAcquire> skipList;
+    {
+        std::lock_guard<std::recursive_mutex> lock(lock_);
+        auto i = skipLists_.find(parameter.finishLedgerHash);
+        if (i != skipLists_.end())
+        {
+            skipList = i->second.lock();
+            if (!skipList)
+            {
+                skipLists_.erase(i);
+                assert(false);
+            }
+        }
+
+        if (!skipList)
+        {
+            skipList = std::make_shared<SkipListAcquire>(
+                app_, parameter.finishLedgerHash, parameter.finishLedgerSeq);
+            skipLists_.emplace(parameter.finishLedgerHash, skipList);
+            // TODO if parameter passed in is full already, don't init
+            needInit = true;
+        }
+    }
+
+    if (needInit)
+        skipList->init(1);
+
+    auto task = std::make_shared<LedgerReplayTask>(
+        app_, skipList, std::move(parameter));
+    if (skipList->addTask(task))
+        task->init();
+}
+
+void
+LedgerReplayer::createDeltas(std::shared_ptr<LedgerReplayTask> task)
+{
+    {
+        // TODO check if the last closed or validated ledger l the local node
+        // has
+        // is in the skip list and is an ancestor of parameter.startLedger that
+        // has to be downloaded, if so expand the task to start with l.
+    }
+    auto const& parameter = task->getTaskTaskParameter();
+    if (parameter.ledgersToBuild > 1)
+    {
+        auto skipListItem = std::find(
+            parameter.skipList.begin(),
+            parameter.skipList.end(),
+            parameter.startLedgerHash);
+        if (skipListItem == parameter.skipList.end())
+        {
+            assert(false);
+            return;
+        }
+        for (std::uint32_t seq = parameter.startLedgerSeq + 1;
+             seq <= parameter.finishLedgerSeq &&
+             skipListItem < parameter.skipList.end();
+             ++seq, ++skipListItem)
+        {
+            bool newDelta = false;
+            std::shared_ptr<LedgerDeltaAcquire> delta;
+            {
+                std::lock_guard<std::recursive_mutex> lock(lock_);
+                auto i = deltas_.find(*skipListItem);
+                if (i != deltas_.end())
+                {
+                    delta = i->second.lock();
+                    if (!delta)
+                    {
+                        deltas_.erase(i);
+                        assert(false);
+                    }
+                }
+
+                if (!delta)
+                {
+                    delta = std::make_shared<LedgerDeltaAcquire>(
+                        app_, *skipListItem, seq);
+                    deltas_.emplace(*skipListItem, delta);
+                    newDelta = true;
+                }
+            }
+
+            if (newDelta)  // TODO rate limit ?? by only init a subset
+                delta->init(1);
+
+            delta->addTask(task);
+        }
+    }
+}
+
+void
+LedgerReplayer::gotProofPath(
+    std::shared_ptr<protocol::TMProofPathResponse> response)
+{
+    protocol::TMProofPathResponse const& reply = *response;
+    if (!reply.has_ledgerheader() || reply.has_error() ||
+        reply.path_size() == 0)
+        return;
+    // deserialize the header
+    auto info = deserializeHeader(
+        {reply.ledgerheader().data(), reply.ledgerheader().size()});
+    if (calculateLedgerHash(info) != info.hash)
+        return;
+
+    // verify the skip list
+    std::vector<Blob> path;
+    path.reserve(reply.path_size());
+    for (int i = 0; i < reply.path_size(); ++i)
+    {
+        path.emplace_back(reply.path(i).begin(), reply.path(i).end());
+    }
+    if (!SHAMap::verifyProofPath(info.accountHash, keylet::skip().key, path))
+        return;
+
+    std::shared_ptr<SkipListAcquire> skipList;
+    {
+        std::lock_guard<std::recursive_mutex> lock(lock_);
+        auto i = skipLists_.find(info.hash);
+        if (i == skipLists_.end())
+            return;
+        auto skipList = i->second.lock();
+        if (!skipList)
+        {
+            skipLists_.erase(i);
+            assert(false);
+            return;
+        }
+    }
+    skipList->processData(path.front());
+}
+
+void
+LedgerReplayer::gotReplayDelta(
+    std::shared_ptr<protocol::TMReplayDeltaResponse> response)
+{
+    auto const& reply = *response;
+
+    if (!reply.has_ledgerheader() || reply.has_error())
+        return;
+
+    // verify the header
+    auto info = deserializeHeader(
+        {reply.ledgerheader().data(), reply.ledgerheader().size()});
+    if (calculateLedgerHash(info) != info.hash)
+        return;
+
+    // TODO verify the transactions hash
+    auto numTxns = reply.transaction_size();
+    std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns;
+    try
+    {
+        for (int i = 0; i < numTxns; ++i)
+        {
+            SerialIter sit(makeSlice(reply.transaction(i)));
+            auto tx = std::make_shared<STTx const>(sit);
+            if (!tx)
+                return;
+            orderedTxns.emplace(i, std::move(tx));
+        }
+    }
+    catch (std::exception const&)
+    {
+        JLOG(j_.error()) << "Peer sends us junky ledger delta data";
+        return;
+    }
+
+    std::shared_ptr<LedgerDeltaAcquire> delta;
+    {
+        std::lock_guard<std::recursive_mutex> lock(lock_);
+        auto i = deltas_.find(info.hash);
+        if (i == deltas_.end())
+            return;
+        auto delta = i->second.lock();
+        if (!delta)
+        {
+            deltas_.erase(i);
+            assert(false);
+            return;
+        }
+    }
+    delta->processData(info, std::move(orderedTxns));
+}
+
+}  // namespace ripple
+
+//    bool
+//    gotLedgerData(
+//        LedgerHash const& hash,
+//        std::shared_ptr<Peer> peer,
+//        std::shared_ptr<protocol::TMLedgerData> packet_ptr)
+//    {
+//        protocol::TMLedgerData& packet = *packet_ptr;
+//
+//        JLOG(j_.trace()) << "Got data (" << packet.nodes().size()
+//                         << ") for acquiring ledger: " << hash;
+//
+//        auto ledger = find(hash);
+//
+//        if (!ledger)
+//        {
+//            JLOG(j_.trace()) << "Got data for ledger we're no longer
+//            acquiring";
+//
+//            // If it's state node data, stash it because it still might be
+//            // useful.
+//            if (packet.type() == protocol::liAS_NODE)
+//            {
+//                app_.getJobQueue().addJob(
+//                    jtLEDGER_DATA, "gotStaleData", [this, packet_ptr](Job&) {
+//                        gotStaleData(packet_ptr);
+//                    });
+//            }
+//
+//            return false;
+//        }
+//
+//        // Stash the data for later processing and see if we need to dispatch
+//        if (ledger->gotData(std::weak_ptr<Peer>(peer), packet_ptr))
+//            app_.getJobQueue().addJob(
+//                jtLEDGER_DATA, "processLedgerData", [this, hash](Job&) {
+//                    doLedgerData(hash);
+//                });
+//
+//        return true;
+//    }

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -28,6 +28,7 @@ namespace ripple {
 LedgerReplayer::LedgerReplayer(Application& app, clock_type& clock)
     : app_(app), clock_(clock), j_(app.journal("LedgerReplayer"))
 {
+    JLOG(j_.debug()) << "LedgerReplayer constructed";
 }
 
 void

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -166,10 +166,7 @@ LedgerReplayer::createDeltas(std::shared_ptr<LedgerReplayTask> task)
                 if (!delta)
                 {
                     delta = std::make_shared<LedgerDeltaAcquire>(
-                        app_,
-                        *skipListItem,
-                        seq,
-                        peerSetBuilder_->build());
+                        app_, *skipListItem, seq, peerSetBuilder_->build());
                     deltas_.emplace(*skipListItem, delta);
                     newDelta = true;
                 }

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -63,7 +63,7 @@ LedgerReplayer::replay(
     bool skipListNeedInit = false;
     {
         std::unique_lock<std::recursive_mutex> lock(lock_);
-        if (tasks_.size() >= LedgerReplayer::MAX_TASKS)
+        if (tasks_.size() >= LedgerReplayParameters::MAX_TASKS)
         {
             JLOG(j_.info()) << "Too many replay tasks, dropping new task "
                             << parameter.finishHash;
@@ -90,7 +90,7 @@ LedgerReplayer::replay(
             skipList = i->second.lock();
             if (!skipList)
             {
-                assert(false);  // TODO remove before PR
+                assert(false);  // TODO remove after tests
                 skipLists_.erase(i);
             }
         }
@@ -163,7 +163,7 @@ LedgerReplayer::createDeltas(std::shared_ptr<LedgerReplayTask> task)
                     delta = i->second.lock();
                     if (!delta)
                     {
-                        assert(false);  // TODO remove before PR
+                        assert(false);  // TODO remove after tests
                         deltas_.erase(i);
                     }
                 }
@@ -205,7 +205,7 @@ LedgerReplayer::gotSkipList(
         if (!skipList)
         {
             skipLists_.erase(i);
-            assert(false);  // TODO remove before PR
+            assert(false);  // TODO remove after tests
             return;
         }
     }
@@ -229,7 +229,7 @@ LedgerReplayer::gotReplayDelta(
         if (!delta)
         {
             deltas_.erase(i);
-            assert(false);  // TODO remove before PR
+            assert(false);  // TODO remove after tests
             return;
         }
     }

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -49,8 +49,9 @@ LedgerReplayer::replay(
     uint256 const& finishLedgerHash,
     std::uint32_t totalNumLedgers)
 {
-    assert(finishLedgerHash.isNonZero() &&
-           totalNumLedgers > 0 && totalNumLedgers <= 256);
+    assert(
+        finishLedgerHash.isNonZero() && totalNumLedgers > 0 &&
+        totalNumLedgers <= 256);
 
     LedgerReplayTask::TaskParameter parameter(
         r, finishLedgerHash, totalNumLedgers);
@@ -71,8 +72,8 @@ LedgerReplayer::replay(
         {
             if (parameter.canMergeInto(t->getTaskParameter()))
             {
-                JLOG(j_.info()) << "Task " << parameter.finishHash
-                                << " with " << totalNumLedgers
+                JLOG(j_.info()) << "Task " << parameter.finishHash << " with "
+                                << totalNumLedgers
                                 << " ledgers merged into an existing task.";
                 return;
             }

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -35,10 +35,11 @@ LedgerReplayer::replay(LedgerReplayTask::TaskParameter&& parameter)
 {
     if (!parameter.isValid())
     {
-        JLOG(j_.warn()) << "LedgerReplayer: bad parameter";
+        JLOG(j_.warn()) << "Bad LedgerReplayTask parameter";
         return;
     }
 
+    JLOG(j_.warn()) << "Replay " << parameter.finishLedgerHash;
     bool needInit = false;
     std::shared_ptr<SkipListAcquire> skipList;
     {
@@ -61,6 +62,8 @@ LedgerReplayer::replay(LedgerReplayTask::TaskParameter&& parameter)
             skipLists_.emplace(parameter.finishLedgerHash, skipList);
             // TODO if parameter passed in is full already, don't init
             needInit = true;
+            JLOG(j_.trace())
+                << "Add SkipListAcquire " << parameter.finishLedgerHash;
         }
     }
 

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -42,6 +42,8 @@ LedgerReplayer::replay(
     uint256 const& finishLedgerHash,
     std::uint32_t totalNumLedgers)
 {
+    if (finishLedgerHash.isZero() || totalNumLedgers > 256)
+        return;
     LedgerReplayTask::TaskParameter parameter(
         r, finishLedgerHash, totalNumLedgers);
 
@@ -88,8 +90,8 @@ void
 LedgerReplayer::createDeltas(std::shared_ptr<LedgerReplayTask> task)
 {
     {
-        // TODO check if the last closed or validated ledger l the local node
-        // has
+        // TODO for use case like Consensus:
+        // check if the last closed or validated ledger l the local node has
         // is in the skip list and is an ancestor of parameter.startLedger that
         // has to be downloaded, if so expand the task to start with l.
     }

--- a/src/ripple/app/ledger/impl/LedgerReplayer.cpp
+++ b/src/ripple/app/ledger/impl/LedgerReplayer.cpp
@@ -68,7 +68,7 @@ LedgerReplayer::replay(
                 *this,
                 parameter.finishHash,
                 parameter.finishSeq,
-                peerSetBuilder_->build(app_));
+                peerSetBuilder_->build());
             skipLists_.emplace(parameter.finishHash, skipList);
             needInit = true;
             JLOG(j_.trace()) << "Add SkipListAcquire " << parameter.finishHash;
@@ -137,7 +137,7 @@ LedgerReplayer::createDeltas(std::shared_ptr<LedgerReplayTask> task)
                         *this,
                         *skipListItem,
                         seq,
-                        peerSetBuilder_->build(app_));
+                        peerSetBuilder_->build());
                     deltas_.emplace(*skipListItem, delta);
                     newDelta = true;
                 }
@@ -201,12 +201,12 @@ LedgerReplayer::onStop()
 {
     hash_set<std::shared_ptr<LedgerReplayTask>> tasks;
     std::lock_guard<std::mutex> lock(lock_);
-    for(auto & [_, sl] : skipLists_)
+    for (auto& [_, sl] : skipLists_)
     {
         auto skipList = sl.lock();
         if (skipList)
         {
-            for(auto & t : skipList->getAllTasks())
+            for (auto& t : skipList->getAllTasks())
             {
                 t->cancel();
             }

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -29,7 +29,7 @@ namespace ripple {
 SkipListAcquire::SkipListAcquire(
     Application& app,
     uint256 const& ledgerHash,
-    std::unique_ptr<PeerSet>&& peerSet)
+    std::unique_ptr<PeerSet> peerSet)
     : TimeoutCounter(
           app,
           ledgerHash,
@@ -180,7 +180,7 @@ SkipListAcquire::notifyTasks(ScopedLockType& psl)
     {
         if (auto sptr = t.lock(); sptr)
         {
-            if(mFailed)
+            if (mFailed)
                 sptr->cancel();
             else
                 sptr->updateSkipList(mHash, ledgerSeq_, skipList_);

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -61,6 +61,7 @@ SkipListAcquire::init(int numPeers)
                 ScopedLockType sl(mLock);
                 mComplete = true;
                 skipList_ = slist;
+                ledgerSeq_ = l->seq();
                 for (auto& t : tasks_)
                 {
                     t->updateSkipList(mHash, ledgerSeq_, skipList_);
@@ -134,7 +135,9 @@ SkipListAcquire::pmDowncast()
 }
 
 void
-SkipListAcquire::processData(std::shared_ptr<SHAMapItem const> const& item)
+SkipListAcquire::processData(
+    std::uint32_t ledgerSeq,
+    std::shared_ptr<SHAMapItem const> const& item)
 {
     JLOG(m_journal.trace()) << "got data for " << mHash;
 
@@ -147,6 +150,7 @@ SkipListAcquire::processData(std::shared_ptr<SHAMapItem const> const& item)
             return;
         mComplete = true;
         skipList_ = sle->getFieldV256(sfHashes).value();
+        ledgerSeq_ = ledgerSeq;
         for (auto& t : tasks_)
         {
             t->updateSkipList(mHash, ledgerSeq_, skipList_);

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -28,7 +28,6 @@ namespace ripple {
 
 SkipListAcquire::SkipListAcquire(
     Application& app,
-    LedgerReplayer& replayer,
     uint256 const& ledgerHash,
     std::unique_ptr<PeerSet>&& peerSet)
     : TimeoutCounter(
@@ -36,15 +35,15 @@ SkipListAcquire::SkipListAcquire(
           ledgerHash,
           LedgerReplayer::SUB_TASK_TIMEOUT,
           app.journal("LedgerReplaySkipList"))
-    , replayer_(replayer)
     , peerSet_(std::move(peerSet))
 {
-    JLOG(m_journal.debug()) << "Acquire skip list " << mHash;
+    JLOG(m_journal.debug()) << "SkipList ctor " << mHash;
 }
 
 SkipListAcquire::~SkipListAcquire()
 {
     JLOG(m_journal.trace()) << "SkipList dtor " << mHash;
+    app_.getLedgerReplayer().removeSkipListAcquire(mHash);
 }
 
 void
@@ -69,7 +68,7 @@ SkipListAcquire::init(int numPeers)
                 }
                 JLOG(m_journal.trace())
                     << "Acquire skip list from existing ledger " << mHash;
-                stopReceive();
+                //stopReceive();
                 return;
             }
         }
@@ -129,7 +128,7 @@ SkipListAcquire::onTimer(bool progress, ScopedLockType& psl)
             if (auto sptr = t.lock(); sptr)
                 sptr->cancel();
         }
-        stopReceive();
+        //stopReceive();
     }
     else
     {
@@ -167,7 +166,7 @@ SkipListAcquire::processData(
                 sptr->updateSkipList(mHash, ledgerSeq_, skipList_);
         }
         // TODO opportunity to merge tasks, probably no need
-        stopReceive();
+        //stopReceive();
     }
 }
 
@@ -191,10 +190,10 @@ SkipListAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
     }
 }
 
-void
-SkipListAcquire::stopReceive()
-{
-    replayer_.removeSkipListAcquire(mHash);
-}
+//void
+//SkipListAcquire::stopReceive()
+//{
+//    app_.getLedgerReplayer().removeSkipListAcquire(mHash);
+//}
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -110,6 +110,10 @@ SkipListAcquire::trigger(std::size_t limit, ScopedLockType& psl)
                 fallBack_ = true;
             }
         });
+
+    if (fallBack_)
+        inboundLedgers_.acquire(
+            mHash, ledgerSeq_, InboundLedger::Reason::GENERIC);
 }
 
 void

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -44,8 +44,7 @@ SkipListAcquire::SkipListAcquire(
 
 SkipListAcquire::~SkipListAcquire()
 {
-    JLOG(m_journal.trace()) << "SkipList dtor, remove myself " << mHash;
-    replayer_.removeSkipListAcquire(mHash);
+    JLOG(m_journal.trace()) << "SkipList dtor " << mHash;
 }
 
 void
@@ -70,6 +69,7 @@ SkipListAcquire::init(int numPeers)
                 }
                 JLOG(m_journal.trace())
                     << "Acquire skip list from existing ledger " << mHash;
+                stopReceive();
                 return;
             }
         }
@@ -129,6 +129,7 @@ SkipListAcquire::onTimer(bool progress, ScopedLockType& psl)
             if (auto sptr = t.lock(); sptr)
                 sptr->cancel();
         }
+        stopReceive();
     }
     else
     {
@@ -166,6 +167,7 @@ SkipListAcquire::processData(
                 sptr->updateSkipList(mHash, ledgerSeq_, skipList_);
         }
         // TODO opportunity to merge tasks, probably no need
+        stopReceive();
     }
 }
 
@@ -187,6 +189,12 @@ SkipListAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
         }
         return true;
     }
+}
+
+void
+SkipListAcquire::stopReceive()
+{
+    replayer_.removeSkipListAcquire(mHash);
 }
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -151,11 +151,11 @@ SkipListAcquire::processData(
         mComplete = true;
         skipList_ = sle->getFieldV256(sfHashes).value();
         ledgerSeq_ = ledgerSeq;
+        JLOG(m_journal.debug()) << "Skip list received " << mHash;
         for (auto& t : tasks_)
         {
             t->updateSkipList(mHash, ledgerSeq_, skipList_);
         }
-        JLOG(m_journal.debug()) << "Skip list received " << mHash;
     }
 }
 

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -68,7 +68,6 @@ SkipListAcquire::init(int numPeers)
                 }
                 JLOG(m_journal.trace())
                     << "Acquire skip list from existing ledger " << mHash;
-                //stopReceive();
                 return;
             }
         }
@@ -128,7 +127,6 @@ SkipListAcquire::onTimer(bool progress, ScopedLockType& psl)
             if (auto sptr = t.lock(); sptr)
                 sptr->cancel();
         }
-        //stopReceive();
     }
     else
     {
@@ -165,8 +163,6 @@ SkipListAcquire::processData(
             if (auto sptr = t.lock(); sptr)
                 sptr->updateSkipList(mHash, ledgerSeq_, skipList_);
         }
-        // TODO opportunity to merge tasks, probably no need
-        //stopReceive();
     }
 }
 
@@ -189,11 +185,5 @@ SkipListAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
         return true;
     }
 }
-
-//void
-//SkipListAcquire::stopReceive()
-//{
-//    app_.getLedgerReplayer().removeSkipListAcquire(mHash);
-//}
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -106,9 +106,11 @@ SkipListAcquire::addPeers(std::size_t limit)
 void
 SkipListAcquire::queueJob()
 {
+    std::weak_ptr<SkipListAcquire> wptr = shared_from_this();
     app_.getJobQueue().addJob(
-        jtREPLAY_TASK, "SkipListAcquire", [ptr = shared_from_this()](Job&) {
-            ptr->invokeOnTimer();
+        jtREPLAY_TASK, "SkipListAcquire", [wptr](Job&) {
+          if(auto sptr = wptr.lock(); sptr)
+                sptr->invokeOnTimer();
         });
 }
 

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -1,0 +1,175 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/InboundLedgers.h>
+#include <ripple/app/ledger/LedgerReplayTask.h>
+#include <ripple/app/ledger/LedgerReplayer.h>
+#include <ripple/app/ledger/impl/LedgerDeltaAcquire.h>
+#include <ripple/app/ledger/impl/SkipListAcquire.h>
+#include <ripple/core/JobQueue.h>
+
+namespace ripple {
+
+using namespace std::chrono_literals;
+// Timeout interval in milliseconds
+auto constexpr ACQUIRE_TIMEOUT = 250ms;
+
+enum {
+    NORM_TIMEOUTS = 4,
+    MAX_TIMEOUTS = 20,
+};
+
+SkipListAcquire::SkipListAcquire(
+    Application& app,
+    uint256 const& ledgerHash,
+    std::uint32_t ledgerSeq)
+    : PeerSet(app, ledgerHash, ACQUIRE_TIMEOUT, app.journal("SkipListAcquire"))
+    , ledgerSeq_(ledgerSeq)
+{
+}
+
+SkipListAcquire::~SkipListAcquire()
+{
+    app_.getLedgerReplayer().removeSkipListAcquire(mHash);
+}
+
+void
+SkipListAcquire::init(int numPeers)
+{
+    ScopedLockType sl(mLock);
+    addPeers(numPeers);
+    setTimer();
+}
+
+void
+SkipListAcquire::addPeers(std::size_t limit)
+{
+    PeerSet::addPeers(limit, [this](auto peer) {
+        return peer->hasLedger(mHash, ledgerSeq_);
+    });
+}
+
+void
+SkipListAcquire::queueJob()
+{
+    app_.getJobQueue().addJob(
+        jtREPLAY_TASK, "SkipListAcquire", [ptr = shared_from_this()](Job&) {
+            ptr->invokeOnTimer();
+        });
+}
+
+void
+SkipListAcquire::onTimer(bool progress, ScopedLockType& psl)
+{
+    if (isDone())
+        return;
+
+    if (mTimeouts > MAX_TIMEOUTS)
+    {
+        mFailed = true;
+        return;
+    }
+
+    addPeers(1);
+}
+
+void
+SkipListAcquire::onPeerAdded(std::shared_ptr<Peer> const& peer)
+{
+    if (mComplete)
+    {
+        // JLOG(m_journal.info()) << "trigger after complete";
+        return;
+    }
+    if (mFailed)
+    {
+        // JLOG(m_journal.info()) << "trigger after fail";
+        return;
+    }
+
+    JLOG(m_journal.trace())
+        << "SkipListAcquire::trigger " << (peer ? "havePeer" : "noPeer")
+        << " hash " << mHash;
+    protocol::TMProofPathRequest request;
+    request.set_ledgerhash(mHash.data(), mHash.size());
+    request.set_key(keylet::skip().key.data(), keylet::skip().key.size());
+    request.set_type(protocol::TMLedgerMapType::lmAS_NODE);
+    auto packet =
+        std::make_shared<Message>(request, protocol::mtProofPathRequest);
+    sendRequest(packet, peer);
+}
+
+std::weak_ptr<PeerSet>
+SkipListAcquire::pmDowncast()
+{
+    return shared_from_this();
+}
+
+void
+SkipListAcquire::processData(Blob const& data)
+{
+    // deserialize the skip list
+    // TODO shorten the deserialize code?? possible exceptions??
+    auto node = SHAMapAbstractNode::makeFromWire(makeSlice(data));
+    if (!node || !node->isLeaf())
+        return;
+    auto item = static_cast<SHAMapTreeNode*>(node.get())->peekItem();
+    if (!item)
+        return;
+    auto sle = std::make_shared<SLE>(
+        SerialIter{item->data(), item->size()}, item->key());
+    if (!sle)
+        return;
+
+    ScopedLockType sl(mLock);
+    if (mComplete)
+        return;
+    mComplete = true;
+    skipList_ = sle->getFieldV256(sfHashes).value();
+    for (auto& t : tasks_)
+    {
+        t->updateSkipList(mHash, ledgerSeq_, skipList_);
+    }
+    JLOG(m_journal.debug()) << "SkipListAcquire received " << mHash;
+}
+
+bool
+SkipListAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
+{
+    ScopedLockType sl(mLock);
+    if (mFailed)
+    {
+        return false;
+    }
+    for (auto const& t : tasks_)
+    {
+        if (task->getTaskTaskParameter().canMergeInto(
+                t->getTaskTaskParameter()))
+            return false;
+    }
+    auto r = tasks_.emplace(task);
+    assert(r.second);
+    if (mComplete)
+    {
+        task->updateSkipList(mHash, ledgerSeq_, skipList_);
+    }
+    return true;
+}
+
+}  // namespace ripple

--- a/src/ripple/app/ledger/impl/SkipListAcquire.cpp
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.cpp
@@ -48,7 +48,7 @@ SkipListAcquire::SkipListAcquire(
 SkipListAcquire::~SkipListAcquire()
 {
     replayer_.removeSkipListAcquire(mHash);
-    JLOG(m_journal.trace()) << "remove myself " << mHash;
+    JLOG(m_journal.trace()) << "SkipList dtor, remove myself " << mHash;
 }
 
 void
@@ -91,7 +91,7 @@ SkipListAcquire::addPeers(std::size_t limit)
         limit,
         [this](auto peer) { return peer->hasLedger(mHash, ledgerSeq_); },
         [this](auto peer) {
-            if (isDone() || !skipList_.empty() || !peer)//TODO need??
+            if (isDone() || !skipList_.empty() || !peer)  // TODO need??
                 return;
 
             JLOG(m_journal.trace())
@@ -101,8 +101,6 @@ SkipListAcquire::addPeers(std::size_t limit)
             request.set_key(
                 keylet::skip().key.data(), keylet::skip().key.size());
             request.set_type(protocol::TMLedgerMapType::lmAS_NODE);
-//            auto packet = std::make_shared<Message>(
-//                request, protocol::mtProofPathRequest);
             peerSet_->sendRequest(request, protocol::mtProofPathRequest, peer);
         });
 }
@@ -173,8 +171,9 @@ SkipListAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
     }
     for (auto const& t : tasks_)
     {
-        if (task->getTaskTaskParameter().canMergeInto(
-                t->getTaskTaskParameter()))
+        if (task->getTaskTaskParameter()
+                .canMergeInto(  // TODO consider no merge
+                    t->getTaskTaskParameter()))
             return false;
     }
     auto r = tasks_.emplace(task);
@@ -186,12 +185,13 @@ SkipListAcquire::addTask(std::shared_ptr<LedgerReplayTask>& task)
     return true;
 }
 
-void
-SkipListAcquire::removeTask(std::shared_ptr<LedgerReplayTask>const& task)
-{
-    ScopedLockType sl(mLock);
-    tasks_.erase(task);
-}
+// void
+// SkipListAcquire::removeTask(std::shared_ptr<LedgerReplayTask> const& task)
+//{
+//    JLOG(m_journal.debug()) << "remove task " << mHash;
+//    ScopedLockType sl(mLock);
+//    tasks_.erase(task);
+//}
 
 hash_set<std::shared_ptr<LedgerReplayTask>>
 SkipListAcquire::getAllTasks()

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012, 2020 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -38,7 +38,7 @@ class LedgerForwardReplay_test;
 class SkipListAcquire final
     : public TimeoutCounter,
       public std::enable_shared_from_this<SkipListAcquire>,
-      public CountedObject<SkipListAcquire>
+      public CountedObject<SkipListAcquire> //TODO
 {
 public:
     static char const*
@@ -77,6 +77,9 @@ private:
 
     void
     addPeers(std::size_t limit);
+
+    void
+    notifyTasks(ScopedLockType& psl);
 
     std::uint32_t ledgerSeq_ = 0;
     std::unique_ptr<PeerSet> peerSet_;

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -69,9 +69,6 @@ public:
     bool
     addTask(std::shared_ptr<LedgerReplayTask>& task);
 
-    hash_set<std::shared_ptr<LedgerReplayTask>>
-    getAllTasks();
-
 private:
     void
     queueJob() override;
@@ -89,7 +86,7 @@ private:
     std::uint32_t ledgerSeq_;
     std::unique_ptr<PeerSet> peerSet_;
     std::vector<ripple::uint256> skipList_;
-    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
+    std::list<std::weak_ptr<LedgerReplayTask>> tasks_;
 
     friend class test::LedgerForwardReplay_test;
 };

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -38,7 +38,7 @@ class LedgerForwardReplay_test;
 class SkipListAcquire final
     : public TimeoutCounter,
       public std::enable_shared_from_this<SkipListAcquire>,
-      public CountedObject<SkipListAcquire> //TODO
+      public CountedObject<SkipListAcquire>
 {
 public:
     static char const*
@@ -50,7 +50,7 @@ public:
     SkipListAcquire(
         Application& app,
         uint256 const& ledgerHash,
-        std::unique_ptr<PeerSet>&& peerSet);
+        std::unique_ptr<PeerSet> peerSet);
 
     ~SkipListAcquire() override;
 

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -1,0 +1,87 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_LEDGER_SKIPLISTACQUIRE_H_INCLUDED
+#define RIPPLE_APP_LEDGER_SKIPLISTACQUIRE_H_INCLUDED
+
+#include <ripple/app/ledger/InboundLedger.h>
+#include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/overlay/PeerSet.h>
+#include <ripple/shamap/SHAMap.h>
+#include <queue>
+
+namespace ripple {
+
+class LedgerReplayTask;
+
+class SkipListAcquire final
+    : public PeerSet,
+      public std::enable_shared_from_this<SkipListAcquire>,
+      public CountedObject<SkipListAcquire>
+{
+public:
+    static char const*
+    getCountedObjectName()
+    {
+        return "SkipListAcquire";
+    }
+
+    using pointer = std::shared_ptr<SkipListAcquire>;
+
+    SkipListAcquire(
+        Application& app,
+        uint256 const& ledgerHash,
+        std::uint32_t ledgerSeq);
+
+    ~SkipListAcquire() override;
+
+    void
+    init(int numPeers);
+
+    void
+    processData(Blob const& data);
+
+    bool
+    addTask(std::shared_ptr<LedgerReplayTask>& task);
+
+private:
+    void
+    queueJob() override;
+
+    void
+    onTimer(bool progress, ScopedLockType& peerSetLock) override;
+
+    void
+    onPeerAdded(std::shared_ptr<Peer> const& peer) override;
+
+    std::weak_ptr<PeerSet>
+    pmDowncast() override;
+
+    void
+    addPeers(std::size_t limit);
+
+    std::uint32_t ledgerSeq_;
+    std::vector<ripple::uint256> skipList_;
+    hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -32,7 +32,7 @@ namespace ripple {
 
 class LedgerReplayTask;
 namespace test {
-class LedgerForwardReplay_test;
+class LedgerReplayClient;
 }  // namespace test
 
 class SkipListAcquire final
@@ -50,6 +50,7 @@ public:
     SkipListAcquire(
         Application& app,
         InboundLedgers& inboundLedgers,
+        LedgerReplayer& replayer,
         uint256 const& ledgerHash,
         std::unique_ptr<PeerSet> peerSet);
 
@@ -94,13 +95,14 @@ private:
     notifyTasks(ScopedLockType& psl);
 
     InboundLedgers& inboundLedgers_;
+    LedgerReplayer& replayer_;
     std::uint32_t ledgerSeq_ = 0;
     std::unique_ptr<PeerSet> peerSet_;
     std::vector<ripple::uint256> skipList_;
     std::list<std::weak_ptr<LedgerReplayTask>> tasks_;
     bool fallBack_ = false;
 
-    friend class test::LedgerForwardReplay_test;
+    friend class test::LedgerReplayClient;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -56,7 +56,9 @@ public:
     init(int numPeers);
 
     void
-    processData(std::shared_ptr<SHAMapItem const> const& item);
+    processData(
+        std::uint32_t ledgerSeq,
+        std::shared_ptr<SHAMapItem const> const& item);
 
     bool
     addTask(std::shared_ptr<LedgerReplayTask>& task);

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -69,9 +69,6 @@ public:
     bool
     addTask(std::shared_ptr<LedgerReplayTask>& task);
 
-    //    void
-    //    removeTask(std::shared_ptr<LedgerReplayTask>const& task);
-
     hash_set<std::shared_ptr<LedgerReplayTask>>
     getAllTasks();
 

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -49,6 +49,7 @@ public:
 
     SkipListAcquire(
         Application& app,
+        InboundLedgers& inboundLedgers,
         uint256 const& ledgerHash,
         std::unique_ptr<PeerSet> peerSet);
 
@@ -76,15 +77,28 @@ private:
     pmDowncast() override;
 
     void
-    addPeers(std::size_t limit);
+    trigger(std::size_t limit, ScopedLockType& psl);
+
+    bool
+    retrieveSkipList(
+        std::shared_ptr<Ledger const> const& ledger,
+        ScopedLockType& psl);
+
+    void
+    onSkipListAcquired(
+        std::vector<uint256> const& skipList,
+        std::uint32_t ledgerSeq,
+        ScopedLockType& psl);
 
     void
     notifyTasks(ScopedLockType& psl);
 
+    InboundLedgers& inboundLedgers_;
     std::uint32_t ledgerSeq_ = 0;
     std::unique_ptr<PeerSet> peerSet_;
     std::vector<ripple::uint256> skipList_;
     std::list<std::weak_ptr<LedgerReplayTask>> tasks_;
+    bool fallBack_ = false;
 
     friend class test::LedgerForwardReplay_test;
 };

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -49,7 +49,6 @@ public:
 
     SkipListAcquire(
         Application& app,
-        LedgerReplayer& replayer,
         uint256 const& ledgerHash,
         std::unique_ptr<PeerSet>&& peerSet);
 
@@ -79,10 +78,9 @@ private:
     void
     addPeers(std::size_t limit);
 
-    void
-    stopReceive();
-
-    LedgerReplayer& replayer_;
+//    void
+//    stopReceive();
+//
     std::uint32_t ledgerSeq_ = 0;
     std::unique_ptr<PeerSet> peerSet_;
     std::vector<ripple::uint256> skipList_;

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -20,9 +20,9 @@
 #ifndef RIPPLE_APP_LEDGER_SKIPLISTACQUIRE_H_INCLUDED
 #define RIPPLE_APP_LEDGER_SKIPLISTACQUIRE_H_INCLUDED
 
-#include <ripple/app/ledger/impl/TimeoutCounter.h>
 #include <ripple/app/ledger/InboundLedger.h>
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/ledger/impl/TimeoutCounter.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/overlay/PeerSet.h>
 #include <ripple/shamap/SHAMap.h>
@@ -31,6 +31,9 @@
 namespace ripple {
 
 class LedgerReplayTask;
+namespace test {
+class LedgerForwardReplay_test;
+}  // namespace test
 
 class SkipListAcquire final
     : public TimeoutCounter,
@@ -51,7 +54,7 @@ public:
         LedgerReplayer& replayer,
         uint256 const& ledgerHash,
         std::uint32_t ledgerSeq,
-        std::unique_ptr<PeerSet> &&peerSet);
+        std::unique_ptr<PeerSet>&& peerSet);
 
     ~SkipListAcquire() override;
 
@@ -66,8 +69,8 @@ public:
     bool
     addTask(std::shared_ptr<LedgerReplayTask>& task);
 
-    void
-    removeTask(std::shared_ptr<LedgerReplayTask>const& task);
+    //    void
+    //    removeTask(std::shared_ptr<LedgerReplayTask>const& task);
 
     hash_set<std::shared_ptr<LedgerReplayTask>>
     getAllTasks();
@@ -91,7 +94,7 @@ private:
     std::vector<ripple::uint256> skipList_;
     hash_set<std::shared_ptr<LedgerReplayTask>> tasks_;
 
-    friend class LedgerForwardReplay_test;
+    friend class test::LedgerForwardReplay_test;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -79,6 +79,9 @@ private:
     void
     addPeers(std::size_t limit);
 
+    void
+    stopReceive();
+
     LedgerReplayer& replayer_;
     std::uint32_t ledgerSeq_ = 0;
     std::unique_ptr<PeerSet> peerSet_;

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -56,7 +56,7 @@ public:
     init(int numPeers);
 
     void
-    processData(Blob const& data);
+    processData(std::shared_ptr<SHAMapItem const> const& item);
 
     bool
     addTask(std::shared_ptr<LedgerReplayTask>& task);

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -78,9 +78,6 @@ private:
     void
     addPeers(std::size_t limit);
 
-//    void
-//    stopReceive();
-//
     std::uint32_t ledgerSeq_ = 0;
     std::unique_ptr<PeerSet> peerSet_;
     std::vector<ripple::uint256> skipList_;

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -79,7 +79,7 @@ private:
     void
     trigger(std::size_t limit, ScopedLockType& psl);
 
-    bool
+    void
     retrieveSkipList(
         std::shared_ptr<Ledger const> const& ledger,
         ScopedLockType& psl);

--- a/src/ripple/app/ledger/impl/SkipListAcquire.h
+++ b/src/ripple/app/ledger/impl/SkipListAcquire.h
@@ -47,13 +47,10 @@ public:
         return "SkipListAcquire";
     }
 
-    using pointer = std::shared_ptr<SkipListAcquire>;
-
     SkipListAcquire(
         Application& app,
         LedgerReplayer& replayer,
         uint256 const& ledgerHash,
-        std::uint32_t ledgerSeq,
         std::unique_ptr<PeerSet>&& peerSet);
 
     ~SkipListAcquire() override;
@@ -83,7 +80,7 @@ private:
     addPeers(std::size_t limit);
 
     LedgerReplayer& replayer_;
-    std::uint32_t ledgerSeq_;
+    std::uint32_t ledgerSeq_ = 0;
     std::unique_ptr<PeerSet> peerSet_;
     std::vector<ripple::uint256> skipList_;
     std::list<std::weak_ptr<LedgerReplayTask>> tasks_;

--- a/src/ripple/app/ledger/impl/TimeoutCounter.cpp
+++ b/src/ripple/app/ledger/impl/TimeoutCounter.cpp
@@ -1,0 +1,88 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/impl/TimeoutCounter.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/core/JobQueue.h>
+#include <ripple/overlay/Overlay.h>
+
+namespace ripple {
+
+using namespace std::chrono_literals;
+
+TimeoutCounter::TimeoutCounter(
+    Application& app,
+    uint256 const& hash,
+    std::chrono::milliseconds interval,
+    beast::Journal journal)
+    : app_(app)
+    , m_journal(journal)
+    , mHash(hash)
+    , mTimeouts(0)
+    , mComplete(false)
+    , mFailed(false)
+    , mProgress(false)
+    , mTimerInterval(interval)
+    , mTimer(app_.getIOService())
+{
+    assert((mTimerInterval > 10ms) && (mTimerInterval < 30s));
+}
+
+TimeoutCounter::~TimeoutCounter() = default;
+
+void
+TimeoutCounter::setTimer()
+{
+    mTimer.expires_after(mTimerInterval);
+    mTimer.async_wait(
+        [wptr = pmDowncast()](boost::system::error_code const& ec) {
+            if (ec == boost::asio::error::operation_aborted)
+                return;
+
+            if (auto ptr = wptr.lock())
+                ptr->queueJob();
+        });
+}
+
+void
+TimeoutCounter::invokeOnTimer()
+{
+    ScopedLockType sl(mLock);
+
+    if (isDone())
+        return;
+
+    if (!mProgress)
+    {
+        ++mTimeouts;
+        JLOG(m_journal.debug()) << "Timeout(" << mTimeouts << ") "
+                                << " acquiring " << mHash;
+        onTimer(false, sl);
+    }
+    else
+    {
+        mProgress = false;
+        onTimer(true, sl);
+    }
+
+    if (!isDone())
+        setTimer();
+}
+
+}  // namespace ripple

--- a/src/ripple/app/ledger/impl/TimeoutCounter.h
+++ b/src/ripple/app/ledger/impl/TimeoutCounter.h
@@ -67,10 +67,6 @@ protected:
         return mComplete || mFailed;
     }
 
-    /** Calls onTimer() if in the right state. */
-    void
-    invokeOnTimer();
-
     /** Schedule a call to queueJob() after mTimerInterval. */
     void
     setTimer();
@@ -90,6 +86,9 @@ protected:
     /** Whether forward progress has been made. */
     bool mProgress;
 
+    /** Calls onTimer() if in the right state. */
+    void
+    invokeOnTimer();
 private:
     /** The minimum time to wait between calls to execute(). */
     std::chrono::milliseconds mTimerInterval;

--- a/src/ripple/app/ledger/impl/TimeoutCounter.h
+++ b/src/ripple/app/ledger/impl/TimeoutCounter.h
@@ -23,10 +23,8 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/beast/clock/abstract_clock.h>
 #include <ripple/beast/utility/Journal.h>
-#include <ripple/overlay/Peer.h>
 #include <boost/asio/basic_waitable_timer.hpp>
 #include <mutex>
-#include <set>
 
 namespace ripple {
 
@@ -35,6 +33,8 @@ namespace ripple {
     and dispatches work to a job queue. Implementations derive
     from this class and override the abstract hook functions in
     the base.
+
+    This class is split from the PeerSet class.  // TODO remove after PR
 */
 class TimeoutCounter
 {

--- a/src/ripple/app/ledger/impl/TimeoutCounter.h
+++ b/src/ripple/app/ledger/impl/TimeoutCounter.h
@@ -89,6 +89,7 @@ protected:
     /** Calls onTimer() if in the right state. */
     void
     invokeOnTimer();
+
 private:
     /** The minimum time to wait between calls to execute(). */
     std::chrono::milliseconds mTimerInterval;

--- a/src/ripple/app/ledger/impl/TimeoutCounter.h
+++ b/src/ripple/app/ledger/impl/TimeoutCounter.h
@@ -1,0 +1,101 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_LEDGER_TIMEOUTCOUNTER_H_INCLUDED
+#define RIPPLE_APP_LEDGER_TIMEOUTCOUNTER_H_INCLUDED
+
+#include <ripple/app/main/Application.h>
+#include <ripple/beast/clock/abstract_clock.h>
+#include <ripple/beast/utility/Journal.h>
+#include <ripple/overlay/Peer.h>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <mutex>
+#include <set>
+
+namespace ripple {
+
+/**
+    This class is an "active" object. It maintains its own timer
+    and dispatches work to a job queue. Implementations derive
+    from this class and override the abstract hook functions in
+    the base.
+*/
+class TimeoutCounter
+{
+protected:
+    using ScopedLockType = std::unique_lock<std::recursive_mutex>;
+
+    TimeoutCounter(
+        Application& app,
+        uint256 const& hash,
+        std::chrono::milliseconds interval,
+        beast::Journal journal);
+
+    virtual ~TimeoutCounter() = 0;
+
+    /** Hook called from invokeOnTimer(). */
+    virtual void
+    onTimer(bool progress, ScopedLockType&) = 0;
+
+    /** Queue a job to call invokeOnTimer(). */
+    virtual void
+    queueJob() = 0;
+
+    /** Return a weak pointer to this. */
+    virtual std::weak_ptr<TimeoutCounter>
+    pmDowncast() = 0;
+
+    bool
+    isDone() const
+    {
+        return mComplete || mFailed;
+    }
+
+    /** Calls onTimer() if in the right state. */
+    void
+    invokeOnTimer();
+
+    /** Schedule a call to queueJob() after mTimerInterval. */
+    void
+    setTimer();
+
+    // Used in this class for access to boost::asio::io_service and
+    // ripple::Overlay. Used in subtypes for the kitchen sink.
+    Application& app_;
+    beast::Journal m_journal;
+    std::recursive_mutex mLock;
+
+    /** The hash of the object (in practice, always a ledger) we are trying to
+     * fetch. */
+    uint256 const mHash;
+    int mTimeouts;
+    bool mComplete;
+    bool mFailed;
+    /** Whether forward progress has been made. */
+    bool mProgress;
+
+private:
+    /** The minimum time to wait between calls to execute(). */
+    std::chrono::milliseconds mTimerInterval;
+    boost::asio::basic_waitable_timer<std::chrono::steady_clock> mTimer;
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/ledger/impl/TransactionAcquire.cpp
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.cpp
@@ -39,9 +39,17 @@ enum {
     MAX_TIMEOUTS = 20,
 };
 
-TransactionAcquire::TransactionAcquire(Application& app, uint256 const& hash)
-    : PeerSet(app, hash, TX_ACQUIRE_TIMEOUT, app.journal("TransactionAcquire"))
+TransactionAcquire::TransactionAcquire(
+    Application& app,
+    uint256 const& hash,
+    std::unique_ptr<PeerSet> peerSet)
+    : TimeoutCounter(
+          app,
+          hash,
+          TX_ACQUIRE_TIMEOUT,
+          app.journal("TransactionAcquire"))
     , mHaveRoot(false)
+    , mPeerSet(std::move(peerSet))
 {
     mMap = std::make_shared<SHAMap>(
         SHAMapType::TRANSACTION, hash, app_.getNodeFamily());
@@ -102,7 +110,7 @@ TransactionAcquire::onTimer(bool progress, ScopedLockType& psl)
     addPeers(1);
 }
 
-std::weak_ptr<PeerSet>
+std::weak_ptr<TimeoutCounter>
 TransactionAcquire::pmDowncast()
 {
     return shared_from_this();
@@ -135,8 +143,9 @@ TransactionAcquire::trigger(std::shared_ptr<Peer> const& peer)
             tmGL.set_querytype(protocol::qtINDIRECT);
 
         *(tmGL.add_nodeids()) = SHAMapNodeID().getRawString();
-        auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
-        sendRequest(packet, peer);
+        //        auto packet = std::make_shared<Message>(tmGL,
+        //        protocol::mtGET_LEDGER); sendRequest(packet, peer);
+        mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
     }
     else if (!mMap->isValid())
     {
@@ -170,8 +179,9 @@ TransactionAcquire::trigger(std::shared_ptr<Peer> const& peer)
         {
             *tmGL.add_nodeids() = node.first.getRawString();
         }
-        auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
-        sendRequest(packet, peer);
+        //        auto packet = std::make_shared<Message>(tmGL,
+        //        protocol::mtGET_LEDGER); sendRequest(packet, peer);
+        mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
     }
 }
 
@@ -247,8 +257,10 @@ TransactionAcquire::takeNodes(
 void
 TransactionAcquire::addPeers(std::size_t limit)
 {
-    PeerSet::addPeers(
-        limit, [this](auto peer) { return peer->hasTxSet(mHash); });
+    mPeerSet->addPeers(
+        limit,
+        [this](auto peer) { return peer->hasTxSet(mHash); },
+        [this](auto peer) { trigger(peer); });
 }
 
 void

--- a/src/ripple/app/ledger/impl/TransactionAcquire.cpp
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.cpp
@@ -135,7 +135,8 @@ TransactionAcquire::trigger(std::shared_ptr<Peer> const& peer)
             tmGL.set_querytype(protocol::qtINDIRECT);
 
         *(tmGL.add_nodeids()) = SHAMapNodeID().getRawString();
-        sendRequest(tmGL, peer);
+        auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+        sendRequest(packet, peer);
     }
     else if (!mMap->isValid())
     {
@@ -169,7 +170,8 @@ TransactionAcquire::trigger(std::shared_ptr<Peer> const& peer)
         {
             *tmGL.add_nodeids() = node.first.getRawString();
         }
-        sendRequest(tmGL, peer);
+        auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+        sendRequest(packet, peer);
     }
 }
 

--- a/src/ripple/app/ledger/impl/TransactionAcquire.cpp
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.cpp
@@ -143,8 +143,6 @@ TransactionAcquire::trigger(std::shared_ptr<Peer> const& peer)
             tmGL.set_querytype(protocol::qtINDIRECT);
 
         *(tmGL.add_nodeids()) = SHAMapNodeID().getRawString();
-        //        auto packet = std::make_shared<Message>(tmGL,
-        //        protocol::mtGET_LEDGER); sendRequest(packet, peer);
         mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
     }
     else if (!mMap->isValid())
@@ -179,8 +177,6 @@ TransactionAcquire::trigger(std::shared_ptr<Peer> const& peer)
         {
             *tmGL.add_nodeids() = node.first.getRawString();
         }
-        //        auto packet = std::make_shared<Message>(tmGL,
-        //        protocol::mtGET_LEDGER); sendRequest(packet, peer);
         mPeerSet->sendRequest(tmGL, protocol::mtGET_LEDGER, peer);
     }
 }

--- a/src/ripple/app/ledger/impl/TransactionAcquire.h
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.h
@@ -29,7 +29,7 @@ namespace ripple {
 // VFALCO TODO rename to PeerTxRequest
 // A transaction set we are trying to acquire
 class TransactionAcquire final
-    : public PeerSet,
+    : public TimeoutCounter,
       public std::enable_shared_from_this<TransactionAcquire>,
       public CountedObject<TransactionAcquire>
 {
@@ -43,7 +43,8 @@ public:
     using pointer = std::shared_ptr<TransactionAcquire>;
 
 public:
-    TransactionAcquire(Application& app, uint256 const& hash);
+    TransactionAcquire(Application& app, uint256 const& hash,
+                       std::unique_ptr<PeerSet> peerSet);
     ~TransactionAcquire() = default;
 
     SHAMapAddNode
@@ -61,18 +62,13 @@ public:
 private:
     std::shared_ptr<SHAMap> mMap;
     bool mHaveRoot;
+    std::unique_ptr<PeerSet> mPeerSet;
 
     void
     queueJob() override;
 
     void
     onTimer(bool progress, ScopedLockType& peerSetLock) override;
-
-    void
-    onPeerAdded(std::shared_ptr<Peer> const& peer) override
-    {
-        trigger(peer);
-    }
 
     void
     done();
@@ -82,7 +78,7 @@ private:
 
     void
     trigger(std::shared_ptr<Peer> const&);
-    std::weak_ptr<PeerSet>
+    std::weak_ptr<TimeoutCounter>
     pmDowncast() override;
 };
 

--- a/src/ripple/app/ledger/impl/TransactionAcquire.h
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.h
@@ -43,8 +43,10 @@ public:
     using pointer = std::shared_ptr<TransactionAcquire>;
 
 public:
-    TransactionAcquire(Application& app, uint256 const& hash,
-                       std::unique_ptr<PeerSet> peerSet);
+    TransactionAcquire(
+        Application& app,
+        uint256 const& hash,
+        std::unique_ptr<PeerSet> peerSet);
     ~TransactionAcquire() = default;
 
     SHAMapAddNode

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1971,7 +1971,7 @@ ApplicationImp::loadOldLedger(
                         0,
                         InboundLedger::Reason::GENERIC,
                         stopwatch(),
-                        nullptr);  // TODO local only, don't need a peerSet
+                        make_DummyPeerSet(*this));
                     if (il->checkLocal())
                         loadLedger = il->getLedger();
                 }
@@ -2015,7 +2015,7 @@ ApplicationImp::loadOldLedger(
                     0,
                     InboundLedger::Reason::GENERIC,
                     stopwatch(),
-                    nullptr);  // TODO local only, don't need a peerSet
+                    make_DummyPeerSet(*this));
 
                 if (il->checkLocal())
                     loadLedger = il->getLedger();

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1233,10 +1233,10 @@ public:
         if (shardStore_)
             shardStore_->sweep();
         getLedgerMaster().sweep();
-        getLedgerReplayer().sweep();
         getTempNodeCache().sweep();
         getValidations().expire();
         getInboundLedgers().sweep();
+        getLedgerReplayer().sweep();
         m_acceptedLedgerCache.sweep();
         cachedSLEs_.expire();
 

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1232,7 +1232,7 @@ public:
         if (shardStore_)
             shardStore_->sweep();
         getLedgerMaster().sweep();
-        // TODO getLedgerReplayer().sweep();
+        getLedgerReplayer().sweep();
         getTempNodeCache().sweep();
         getValidations().expire();
         getInboundLedgers().sweep();

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -57,6 +57,7 @@
 #include <ripple/nodestore/DummyScheduler.h>
 #include <ripple/overlay/Cluster.h>
 #include <ripple/overlay/PeerReservationTable.h>
+#include <ripple/overlay/PeerSet.h>
 #include <ripple/overlay/make_Overlay.h>
 #include <ripple/protocol/BuildInfo.h>
 #include <ripple/protocol/Feature.h>
@@ -335,8 +336,10 @@ public:
               m_collectorManager->collector(),
               logs_->journal("LedgerMaster")))
 
-        , m_ledgerReplayer(std::make_unique<LedgerReplayer>(*this, stopwatch()))
-        // logs_->journal("LedgerReplayer")))
+        , m_ledgerReplayer(std::make_unique<LedgerReplayer>(
+              *this,
+              make_PeerSetBuilder(),
+              *m_jobQueue))
 
         // VFALCO NOTE must come before NetworkOPs to prevent a crash due
         //             to dependencies in the destructor.
@@ -1967,7 +1970,8 @@ ApplicationImp::loadOldLedger(
                         hash,
                         0,
                         InboundLedger::Reason::GENERIC,
-                        stopwatch());
+                        stopwatch(),
+                        nullptr);  // TODO local only, don't need a peerSet
                     if (il->checkLocal())
                         loadLedger = il->getLedger();
                 }
@@ -2010,7 +2014,8 @@ ApplicationImp::loadOldLedger(
                     replayLedger->info().parentHash,
                     0,
                     InboundLedger::Reason::GENERIC,
-                    stopwatch());
+                    stopwatch(),
+                    nullptr);  // TODO local only, don't need a peerSet
 
                 if (il->checkLocal())
                     loadLedger = il->getLedger();

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -338,7 +338,7 @@ public:
 
         , m_ledgerReplayer(std::make_unique<LedgerReplayer>(
               *this,
-              make_PeerSetBuilder(),
+              make_PeerSetBuilder(*this),
               *m_jobQueue))
 
         // VFALCO NOTE must come before NetworkOPs to prevent a crash due

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -186,9 +186,9 @@ public:
     OrderBookDB m_orderBookDB;
     std::unique_ptr<PathRequests> m_pathRequests;
     std::unique_ptr<LedgerMaster> m_ledgerMaster;
-    std::unique_ptr<LedgerReplayer> m_ledgerReplayer;
     std::unique_ptr<InboundLedgers> m_inboundLedgers;
     std::unique_ptr<InboundTransactions> m_inboundTransactions;
+    std::unique_ptr<LedgerReplayer> m_ledgerReplayer;
     TaggedCache<uint256, AcceptedLedger> m_acceptedLedgerCache;
     std::unique_ptr<NetworkOPs> m_networkOPs;
     std::unique_ptr<Cluster> cluster_;
@@ -336,11 +336,6 @@ public:
               m_collectorManager->collector(),
               logs_->journal("LedgerMaster")))
 
-        , m_ledgerReplayer(std::make_unique<LedgerReplayer>(
-              *this,
-              make_PeerSetBuilder(*this),
-              *m_jobQueue))
-
         // VFALCO NOTE must come before NetworkOPs to prevent a crash due
         //             to dependencies in the destructor.
         //
@@ -357,6 +352,12 @@ public:
               [this](std::shared_ptr<SHAMap> const& set, bool fromAcquire) {
                   gotTXSet(set, fromAcquire);
               }))
+
+        , m_ledgerReplayer(std::make_unique<LedgerReplayer>(
+              *this,
+              *m_inboundLedgers,
+              make_PeerSetBuilder(*this),
+              *m_jobQueue))
 
         , m_acceptedLedgerCache(
               "AcceptedLedger",

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -63,6 +63,7 @@ class InboundLedgers;
 class InboundTransactions;
 class AcceptedLedger;
 class LedgerMaster;
+class LedgerReplayer;
 class LoadManager;
 class ManifestCache;
 class ValidatorKeys;
@@ -200,6 +201,8 @@ public:
 
     virtual LedgerMaster&
     getLedgerMaster() = 0;
+    virtual LedgerReplayer&
+    getLedgerReplayer() = 0;
     virtual NetworkOPs&
     getOPs() = 0;
     virtual OrderBookDB&

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -173,14 +173,14 @@ public:
     // Compression
     bool COMPRESSION = false;
 
+    // Enable the experimental Ledger Replay functionality
+    bool LEDGER_REPLAY = false;
+
     // Amendment majority time
     std::chrono::seconds AMENDMENT_MAJORITY_TIME = defaultAmendmentMajorityTime;
 
     // Thread pool configuration
     std::size_t WORKERS = 0;
-
-    // Enable the experimental Ledger Replay functionality
-    bool LEDGER_REPLAY = false;
 
     // These override the command line client settings
     boost::optional<beast::IP::Endpoint> rpc_ip;

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -179,6 +179,9 @@ public:
     // Thread pool configuration
     std::size_t WORKERS = 0;
 
+    // Enable the experimental Ledger Replay functionality
+    bool LEDGER_REPLAY_ENABLE = false;
+
     // These override the command line client settings
     boost::optional<beast::IP::Endpoint> rpc_ip;
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -180,7 +180,7 @@ public:
     std::size_t WORKERS = 0;
 
     // Enable the experimental Ledger Replay functionality
-    bool LEDGER_REPLAY_ENABLE = false;
+    bool LEDGER_REPLAY = false;
 
     // These override the command line client settings
     boost::optional<beast::IP::Endpoint> rpc_ip;

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -89,6 +89,7 @@ struct ConfigSection
 #define SECTION_VALIDATOR_TOKEN "validator_token"
 #define SECTION_VETO_AMENDMENTS "veto_amendments"
 #define SECTION_WORKERS "workers"
+#define SECTION_LEDGER_REPLAY "ledger_replay"
 
 }  // namespace ripple
 

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -45,7 +45,7 @@ enum JobType {
     jtREPLAY_REQ,     // Peer request a ledger delta or a skip list
     jtLEDGER_REQ,     // Peer request ledger/txnset data
     jtPROPOSAL_ut,    // A proposal from an untrusted source
-    jtREPLAY_TASK,    // A Ledger replay task
+    jtREPLAY_TASK,    // A Ledger replay task/subtask
     jtLEDGER_DATA,    // Received data for a ledger we're acquiring
     jtCLIENT,         // A websocket command from the client
     jtRPC,            // A websocket command from the client

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -63,6 +63,14 @@ enum JobType {
     jtNETOP_TIMER,    // NetworkOPs net timer processing
     jtADMIN,          // An administrative operation
 
+    jtPROOF_PATH_REQUEST,     // Peer request the proof path of a ledger ShaMap
+                              // node
+    jtPROOF_PATH_RESPONSE,    // Received response of the proof path we're
+                              // acquiring
+    jtREPLAY_DELTA_REQUEST,   // Peer request the replay delta of a ledger
+    jtREPLAY_DELTA_RESPONSE,  // Received response of the replay delta we're
+                              // acquiring
+
     // Special job types which are not dispatched by the job pool
     jtPEER,
     jtDISK,

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -63,13 +63,10 @@ enum JobType {
     jtNETOP_TIMER,    // NetworkOPs net timer processing
     jtADMIN,          // An administrative operation
 
-    jtPROOF_PATH_REQUEST,     // Peer request the proof path of a ledger ShaMap
-                              // node
-    jtPROOF_PATH_RESPONSE,    // Received response of the proof path we're
-                              // acquiring
-    jtREPLAY_DELTA_REQUEST,   // Peer request the replay delta of a ledger
-    jtREPLAY_DELTA_RESPONSE,  // Received response of the replay delta we're
-                              // acquiring
+    jtREPLAY_TASK,           // A Ledger replay task
+    jtREPLAY_DELTA,          // A Ledger replay sub-task
+    jtPROOF_PATH_REQUEST,    // Peer requests a ShaMap proof path
+    jtREPLAY_DELTA_REQUEST,  // Peer request a ledger delta
 
     // Special job types which are not dispatched by the job pool
     jtPEER,

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -42,8 +42,12 @@ enum JobType {
     jtPUBOLDLEDGER,   // An old ledger has been accepted
     jtVALIDATION_ut,  // A validation from an untrusted source
     jtTRANSACTION_l,  // A local transaction
+    jtPROOFPATH_REQ,  // Peer requests a ShaMap proof path
+    jtREPLYDLTA_REQ,  // Peer request a ledger delta
     jtLEDGER_REQ,     // Peer request ledger/txnset data
     jtPROPOSAL_ut,    // A proposal from an untrusted source
+    jtREPLAY_TASK,    // A Ledger replay task
+    jtREPLAY_DELTA,   // A Ledger replay sub-task
     jtLEDGER_DATA,    // Received data for a ledger we're acquiring
     jtCLIENT,         // A websocket command from the client
     jtRPC,            // A websocket command from the client
@@ -62,11 +66,6 @@ enum JobType {
     jtNETOP_CLUSTER,  // NetworkOPs cluster peer report
     jtNETOP_TIMER,    // NetworkOPs net timer processing
     jtADMIN,          // An administrative operation
-
-    jtREPLAY_TASK,           // A Ledger replay task
-    jtREPLAY_DELTA,          // A Ledger replay sub-task
-    jtPROOF_PATH_REQUEST,    // Peer requests a ShaMap proof path
-    jtREPLAY_DELTA_REQUEST,  // Peer request a ledger delta
 
     // Special job types which are not dispatched by the job pool
     jtPEER,

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -42,12 +42,10 @@ enum JobType {
     jtPUBOLDLEDGER,   // An old ledger has been accepted
     jtVALIDATION_ut,  // A validation from an untrusted source
     jtTRANSACTION_l,  // A local transaction
-    jtPROOFPATH_REQ,  // Peer requests a ShaMap proof path
-    jtREPLYDLTA_REQ,  // Peer request a ledger delta
+    jtREPLAY_REQ,     // Peer request a ledger delta or a skip list
     jtLEDGER_REQ,     // Peer request ledger/txnset data
     jtPROPOSAL_ut,    // A proposal from an untrusted source
     jtREPLAY_TASK,    // A Ledger replay task
-    jtREPLAY_DELTA,   // A Ledger replay sub-task
     jtLEDGER_DATA,    // Received data for a ledger we're acquiring
     jtCLIENT,         // A websocket command from the client
     jtRPC,            // A websocket command from the client

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -61,7 +61,7 @@ private:
         add(jtPROPOSAL_ut, "untrustedProposal", maxLimit, false, 500ms, 1250ms);
         add(jtLEDGER_DATA, "ledgerData", 2, false, 0ms, 0ms);
         add(jtREPLAY_TASK, "ledgerReplayTask", maxLimit, false, 0ms, 0ms);
-        add(jtREPLAY_REQ, "ledgerReplayRequest", 10, false, 0ms, 0ms);
+        add(jtREPLAY_REQ, "ledgerReplayRequest", 10, false, 250ms, 1000ms);
         add(jtCLIENT, "clientCommand", maxLimit, false, 2000ms, 5000ms);
         add(jtRPC, "RPC", maxLimit, false, 0ms, 0ms);
         add(jtUPDATE_PF, "updatePaths", maxLimit, false, 0ms, 0ms);

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -57,11 +57,11 @@ private:
             2000ms,
             5000ms);
         add(jtTRANSACTION_l, "localTransaction", maxLimit, false, 100ms, 500ms);
+        add(jtREPLAY_REQ, "ledgerReplayRequest", 10, false, 250ms, 1000ms);
         add(jtLEDGER_REQ, "ledgerRequest", 2, false, 0ms, 0ms);
         add(jtPROPOSAL_ut, "untrustedProposal", maxLimit, false, 500ms, 1250ms);
-        add(jtLEDGER_DATA, "ledgerData", 2, false, 0ms, 0ms);
         add(jtREPLAY_TASK, "ledgerReplayTask", maxLimit, false, 0ms, 0ms);
-        add(jtREPLAY_REQ, "ledgerReplayRequest", 10, false, 250ms, 1000ms);
+        add(jtLEDGER_DATA, "ledgerData", 2, false, 0ms, 0ms);
         add(jtCLIENT, "clientCommand", maxLimit, false, 2000ms, 5000ms);
         add(jtRPC, "RPC", maxLimit, false, 0ms, 0ms);
         add(jtUPDATE_PF, "updatePaths", maxLimit, false, 0ms, 0ms);

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -60,12 +60,10 @@ private:
         add(jtLEDGER_REQ, "ledgerRequest", 2, false, 0ms, 0ms);
         add(jtPROPOSAL_ut, "untrustedProposal", maxLimit, false, 500ms, 1250ms);
         add(jtLEDGER_DATA, "ledgerData", 2, false, 0ms, 0ms);
-        // TODO understand the parameters
         add(jtREPLAY_TASK, "ledgerReplayTask", maxLimit, false, 0ms, 0ms);
         add(jtREPLAY_DELTA, "ledgerReplayDelta", maxLimit, false, 0ms, 0ms);
-        add(jtPROOF_PATH_REQUEST, "proofPathRequest", 10, false, 0ms, 0ms);
-        add(jtREPLAY_DELTA_REQUEST, "replayDeltaRequest", 10, false, 0ms, 0ms);
-
+        add(jtPROOFPATH_REQ, "proofPathRequest", 10, false, 0ms, 0ms);
+        add(jtREPLYDLTA_REQ, "replayDeltaRequest", 10, false, 0ms, 0ms);
         add(jtCLIENT, "clientCommand", maxLimit, false, 2000ms, 5000ms);
         add(jtRPC, "RPC", maxLimit, false, 0ms, 0ms);
         add(jtUPDATE_PF, "updatePaths", maxLimit, false, 0ms, 0ms);

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -60,6 +60,10 @@ private:
         add(jtLEDGER_REQ, "ledgerRequest", 2, false, 0ms, 0ms);
         add(jtPROPOSAL_ut, "untrustedProposal", maxLimit, false, 500ms, 1250ms);
         add(jtLEDGER_DATA, "ledgerData", 2, false, 0ms, 0ms);
+        // TODO understand the parameters
+        add(jtPROOF_PATH_REQUEST, "proofPathRequest", 2, false, 0ms, 0ms);
+        add(jtREPLAY_DELTA_REQUEST, "replayDeltaRequest", 2, false, 0ms, 0ms);
+
         add(jtCLIENT, "clientCommand", maxLimit, false, 2000ms, 5000ms);
         add(jtRPC, "RPC", maxLimit, false, 0ms, 0ms);
         add(jtUPDATE_PF, "updatePaths", maxLimit, false, 0ms, 0ms);

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -61,9 +61,7 @@ private:
         add(jtPROPOSAL_ut, "untrustedProposal", maxLimit, false, 500ms, 1250ms);
         add(jtLEDGER_DATA, "ledgerData", 2, false, 0ms, 0ms);
         add(jtREPLAY_TASK, "ledgerReplayTask", maxLimit, false, 0ms, 0ms);
-        add(jtREPLAY_DELTA, "ledgerReplayDelta", maxLimit, false, 0ms, 0ms);
-        add(jtPROOFPATH_REQ, "proofPathRequest", 10, false, 0ms, 0ms);
-        add(jtREPLYDLTA_REQ, "replayDeltaRequest", 10, false, 0ms, 0ms);
+        add(jtREPLAY_REQ, "ledgerReplayRequest", 10, false, 0ms, 0ms);
         add(jtCLIENT, "clientCommand", maxLimit, false, 2000ms, 5000ms);
         add(jtRPC, "RPC", maxLimit, false, 0ms, 0ms);
         add(jtUPDATE_PF, "updatePaths", maxLimit, false, 0ms, 0ms);

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -61,8 +61,10 @@ private:
         add(jtPROPOSAL_ut, "untrustedProposal", maxLimit, false, 500ms, 1250ms);
         add(jtLEDGER_DATA, "ledgerData", 2, false, 0ms, 0ms);
         // TODO understand the parameters
-        add(jtPROOF_PATH_REQUEST, "proofPathRequest", 2, false, 0ms, 0ms);
-        add(jtREPLAY_DELTA_REQUEST, "replayDeltaRequest", 2, false, 0ms, 0ms);
+        add(jtREPLAY_TASK, "ledgerReplayTask", maxLimit, false, 0ms, 0ms);
+        add(jtREPLAY_DELTA, "ledgerReplayDelta", maxLimit, false, 0ms, 0ms);
+        add(jtPROOF_PATH_REQUEST, "proofPathRequest", 10, false, 0ms, 0ms);
+        add(jtREPLAY_DELTA_REQUEST, "replayDeltaRequest", 10, false, 0ms, 0ms);
 
         add(jtCLIENT, "clientCommand", maxLimit, false, 2000ms, 5000ms);
         add(jtRPC, "RPC", maxLimit, false, 0ms, 0ms);

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -481,6 +481,12 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_COMPRESSION, strTemp, j_))
         COMPRESSION = beast::lexicalCastThrow<bool>(strTemp);
 
+    if (exists(SECTION_LEDGER_REPLAY))
+    {
+        auto sec = section(SECTION_LEDGER_REPLAY);
+        LEDGER_REPLAY_ENABLE = sec.value_or("enable", false);
+    }
+
     if (getSingleSection(
             secConfig, SECTION_AMENDMENT_MAJORITY_TIME, strTemp, j_))
     {

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -484,7 +484,7 @@ Config::loadFromString(std::string const& fileContents)
     if (exists(SECTION_LEDGER_REPLAY))
     {
         auto sec = section(SECTION_LEDGER_REPLAY);
-        LEDGER_REPLAY_ENABLE = sec.value_or("enable", false);
+        LEDGER_REPLAY = sec.value_or("enable", false);
     }
 
     if (getSingleSection(

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -481,11 +481,8 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_COMPRESSION, strTemp, j_))
         COMPRESSION = beast::lexicalCastThrow<bool>(strTemp);
 
-    if (exists(SECTION_LEDGER_REPLAY))
-    {
-        auto sec = section(SECTION_LEDGER_REPLAY);
-        LEDGER_REPLAY = sec.value_or("enable", false);
-    }
+    if (getSingleSection(secConfig, SECTION_LEDGER_REPLAY, strTemp, j_))
+        LEDGER_REPLAY = beast::lexicalCastThrow<bool>(strTemp);
 
     if (getSingleSection(
             secConfig, SECTION_AMENDMENT_MAJORITY_TIME, strTemp, j_))

--- a/src/ripple/overlay/Peer.h
+++ b/src/ripple/overlay/Peer.h
@@ -37,6 +37,7 @@ static constexpr std::uint32_t csHopLimit = 3;
 
 enum class ProtocolFeature {
     ValidatorListPropagation,
+    LedgerReplay,
 };
 
 /** Represents a peer connection in the overlay. */

--- a/src/ripple/overlay/PeerSet.h
+++ b/src/ripple/overlay/PeerSet.h
@@ -39,6 +39,9 @@ namespace ripple {
     on whether the peers have useful information.
 
     The data is represented by its hash.
+
+    The original PeerSet is split to two. The logic for counting timeouts
+    is move to the new TimeoutCounter class.  // TODO remove after PR
 */
 
 class PeerSet
@@ -46,12 +49,19 @@ class PeerSet
 public:
     virtual ~PeerSet() = default;
 
+    /**
+     * Try add more peers
+     * @param limit  number of peers to add
+     * @param hasItem  callback that helps to select peers
+     * @param onPeerAdded  callback called when a peer is added
+     */
     virtual void
     addPeers(
         std::size_t limit,
         std::function<bool(std::shared_ptr<Peer> const&)> hasItem,
         std::function<void(std::shared_ptr<Peer> const&)> onPeerAdded) = 0;
 
+    /** send a message */
     virtual void
     sendRequest(
         ::google::protobuf::Message const& message,
@@ -81,8 +91,6 @@ make_PeerSetBuilder(Application& app);
  * Make a dummy PeerSet that does not do anything.
  * @note For the use case of InboundLedger in ApplicationImp::loadOldLedger(),
  *       where a real PeerSet is not needed.
- * @param app
- * @return
  */
 std::unique_ptr<PeerSet>
 make_DummyPeerSet(Application& app);

--- a/src/ripple/overlay/PeerSet.h
+++ b/src/ripple/overlay/PeerSet.h
@@ -68,14 +68,24 @@ public:
 class PeerSetBuilder
 {
 public:
+    virtual ~PeerSetBuilder() = default;
+
     virtual std::unique_ptr<PeerSet>
     build() = 0;
-
-    virtual ~PeerSetBuilder() = default;
 };
 
 std::unique_ptr<PeerSetBuilder>
 make_PeerSetBuilder(Application& app);
+
+/**
+ * Make a dummy PeerSet that does not do anything.
+ * @note For the use case of InboundLedger in ApplicationImp::loadOldLedger(),
+ *       where a real PeerSet is not needed.
+ * @param app
+ * @return
+ */
+std::unique_ptr<PeerSet>
+make_DummyPeerSet(Application& app);
 
 }  // namespace ripple
 

--- a/src/ripple/overlay/PeerSet.h
+++ b/src/ripple/overlay/PeerSet.h
@@ -38,96 +38,44 @@ namespace ripple {
     Callers maintain the set by adding and removing peers depending
     on whether the peers have useful information.
 
-    This class is an "active" object. It maintains its own timer
-    and dispatches work to a job queue. Implementations derive
-    from this class and override the abstract hook functions in
-    the base.
-
     The data is represented by its hash.
 */
+
 class PeerSet
 {
-protected:
-    using ScopedLockType = std::unique_lock<std::recursive_mutex>;
+public:
+    virtual ~PeerSet()  = default;
 
-    PeerSet(
-        Application& app,
-        uint256 const& hash,
-        std::chrono::milliseconds interval,
-        beast::Journal journal);
-
-    virtual ~PeerSet() = 0;
-
-    /** Add at most `limit` peers to this set from the overlay. */
-    void
+    virtual void
     addPeers(
         std::size_t limit,
-        std::function<bool(std::shared_ptr<Peer> const&)> score);
+        std::function<bool(std::shared_ptr<Peer> const&)> hasItem,
+        std::function<void(std::shared_ptr<Peer> const&)> onPeerAdded) = 0;
 
-    /** Hook called from addPeers().
-     * @note holding a recursive_mutex
-     **/
     virtual void
-    onPeerAdded(std::shared_ptr<Peer> const&) = 0;
-
-    /** Hook called from invokeOnTimer(). */
-    virtual void
-    onTimer(bool progress, ScopedLockType&) = 0;
-
-    /** Queue a job to call invokeOnTimer(). */
-    virtual void
-    queueJob() = 0;
-
-    /** Return a weak pointer to this. */
-    virtual std::weak_ptr<PeerSet>
-    pmDowncast() = 0;
-
-    bool
-    isDone() const
-    {
-        return mComplete || mFailed;
-    }
-
-    /** Calls onTimer() if in the right state. */
-    void
-    invokeOnTimer();
-
-    /** Send a GetLedger message to one or all peers. */
-    void
     sendRequest(
-        std::shared_ptr<Message> const& packet,
-        // const protocol::TMGetLedger& message,
-        std::shared_ptr<Peer> const& peer);
+        ::google::protobuf::Message const& message,
+        protocol::MessageType type,
+        std::shared_ptr<Peer> const& peer) = 0;
 
-    /** Schedule a call to queueJob() after mTimerInterval. */
-    void
-    setTimer();
+    virtual void
+    visitAddedPeers(std::function<void(Peer::id_t)> onPeer) = 0;
 
-    // Used in this class for access to boost::asio::io_service and
-    // ripple::Overlay. Used in subtypes for the kitchen sink.
-    Application& app_;
-    beast::Journal m_journal;
-
-    std::recursive_mutex mLock;
-
-    /** The hash of the object (in practice, always a ledger) we are trying to
-     * fetch. */
-    uint256 const mHash;
-    int mTimeouts;
-    bool mComplete;
-    bool mFailed;
-    /** Whether forward progress has been made. */
-    bool mProgress;
-
-    /** The identifiers of the peers we are tracking. */
-    std::set<Peer::id_t> mPeers;
-
-private:
-    /** The minimum time to wait between calls to execute(). */
-    std::chrono::milliseconds mTimerInterval;
-    // VFALCO TODO move the responsibility for the timer to a higher level
-    boost::asio::basic_waitable_timer<std::chrono::steady_clock> mTimer;
+    virtual std::size_t
+    countAddedPeers() = 0;
 };
+
+class PeerSetBuilder
+{
+public:
+    virtual std::unique_ptr<PeerSet>
+    build(Application& app) = 0;
+
+    virtual ~PeerSetBuilder() = default;
+};
+
+std::unique_ptr<PeerSetBuilder>
+make_PeerSetBuilder();
 
 }  // namespace ripple
 

--- a/src/ripple/overlay/PeerSet.h
+++ b/src/ripple/overlay/PeerSet.h
@@ -93,7 +93,8 @@ protected:
     /** Send a GetLedger message to one or all peers. */
     void
     sendRequest(
-        const protocol::TMGetLedger& message,
+        std::shared_ptr<Message> const& packet,
+        // const protocol::TMGetLedger& message,
         std::shared_ptr<Peer> const& peer);
 
     /** Schedule a call to queueJob() after mTimerInterval. */

--- a/src/ripple/overlay/PeerSet.h
+++ b/src/ripple/overlay/PeerSet.h
@@ -64,7 +64,9 @@ protected:
         std::size_t limit,
         std::function<bool(std::shared_ptr<Peer> const&)> score);
 
-    /** Hook called from addPeers(). */
+    /** Hook called from addPeers().
+     * @note holding a recursive_mutex
+     **/
     virtual void
     onPeerAdded(std::shared_ptr<Peer> const&) = 0;
 

--- a/src/ripple/overlay/PeerSet.h
+++ b/src/ripple/overlay/PeerSet.h
@@ -44,7 +44,7 @@ namespace ripple {
 class PeerSet
 {
 public:
-    virtual ~PeerSet()  = default;
+    virtual ~PeerSet() = default;
 
     virtual void
     addPeers(
@@ -69,13 +69,13 @@ class PeerSetBuilder
 {
 public:
     virtual std::unique_ptr<PeerSet>
-    build(Application& app) = 0;
+    build() = 0;
 
     virtual ~PeerSetBuilder() = default;
 };
 
 std::unique_ptr<PeerSetBuilder>
-make_PeerSetBuilder();
+make_PeerSetBuilder(Application& app);
 
 }  // namespace ripple
 

--- a/src/ripple/overlay/impl/ConnectAttempt.cpp
+++ b/src/ripple/overlay/impl/ConnectAttempt.cpp
@@ -202,7 +202,9 @@ ConnectAttempt::onHandshake(error_code ec)
         return close();  // makeSharedValue logs
 
     req_ = makeRequest(
-        !overlay_.peerFinder().config().peerPrivate, app_.config().COMPRESSION);
+        !overlay_.peerFinder().config().peerPrivate,
+        app_.config().COMPRESSION,
+        app_.config().LEDGER_REPLAY);
 
     buildHandshake(
         req_,
@@ -282,7 +284,10 @@ ConnectAttempt::onShutdown(error_code ec)
 //--------------------------------------------------------------------------
 
 auto
-ConnectAttempt::makeRequest(bool crawl, bool compressionEnabled) -> request_type
+ConnectAttempt::makeRequest(
+    bool crawl,
+    bool compressionEnabled,
+    bool ledgerReplayEnabled) -> request_type
 {
     request_type m;
     m.method(boost::beast::http::verb::get);
@@ -295,6 +300,8 @@ ConnectAttempt::makeRequest(bool crawl, bool compressionEnabled) -> request_type
     m.insert("Crawl", crawl ? "public" : "private");
     if (compressionEnabled)
         m.insert("X-Offer-Compression", "lz4");
+    if (ledgerReplayEnabled)
+        m.insert("X-Offer-LedgerReplay", "1");
     return m;
 }
 

--- a/src/ripple/overlay/impl/ConnectAttempt.h
+++ b/src/ripple/overlay/impl/ConnectAttempt.h
@@ -105,8 +105,11 @@ private:
     void
     onShutdown(error_code ec);
 
+    // TODO to be refactored.
+    // Greg plans to refactor this function and the related code.
+    // I will adapt once that PR is merged.
     static request_type
-    makeRequest(bool crawl, bool compressionEnabled);
+    makeRequest(bool crawl, bool compressionEnabled, bool ledgerReplayEnabled);
 
     void
     processResponse();

--- a/src/ripple/overlay/impl/Message.cpp
+++ b/src/ripple/overlay/impl/Message.cpp
@@ -64,6 +64,7 @@ Message::compress()
             case protocol::mtLEDGER_DATA:
             case protocol::mtGET_OBJECTS:
             case protocol::mtVALIDATORLIST:
+            case protocol::mtREPLAY_DELTA_RESPONSE:
                 return true;
             case protocol::mtPING:
             case protocol::mtCLUSTER:
@@ -75,6 +76,9 @@ Message::compress()
             case protocol::mtSHARD_INFO:
             case protocol::mtGET_PEER_SHARD_INFO:
             case protocol::mtPEER_SHARD_INFO:
+            case protocol::mtPROOF_PATH_REQ:
+            case protocol::mtPROOF_PATH_RESPONSE:
+            case protocol::mtREPLAY_DELTA_REQ:
                 break;
         }
         return false;

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1560,7 +1560,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProofPathRequest> const& m)
     fee_ = Resource::feeMediumBurdenPeer;  // TODO understand
     std::weak_ptr<PeerImp> weak = shared_from_this();
     app_.getJobQueue().addJob(
-        jtPROOFPATH_REQ, "recvProofPathRequest", [weak, m](Job&) {
+        jtREPLAY_REQ, "recvProofPathRequest", [weak, m](Job&) {
             if (auto peer = weak.lock())
                 peer->getProofPath(m);
         });
@@ -1579,7 +1579,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMReplayDeltaRequest> const& m)
     fee_ = Resource::feeMediumBurdenPeer;
     std::weak_ptr<PeerImp> weak = shared_from_this();
     app_.getJobQueue().addJob(
-        jtREPLYDLTA_REQ, "recvReplayDeltaRequest", [weak, m](Job&) {
+        jtREPLAY_REQ, "recvReplayDeltaRequest", [weak, m](Job&) {
             if (auto peer = weak.lock())
                 peer->getReplayDelta(m);
         });

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1560,7 +1560,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProofPathRequest> const& m)
     fee_ = Resource::feeMediumBurdenPeer;  // TODO understand
     std::weak_ptr<PeerImp> weak = shared_from_this();
     app_.getJobQueue().addJob(
-        jtPROOF_PATH_REQUEST, "recvProofPathRequest", [weak, m](Job&) {
+        jtPROOFPATH_REQ, "recvProofPathRequest", [weak, m](Job&) {
             if (auto peer = weak.lock())
                 peer->getProofPath(m);
         });
@@ -1579,7 +1579,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMReplayDeltaRequest> const& m)
     fee_ = Resource::feeMediumBurdenPeer;
     std::weak_ptr<PeerImp> weak = shared_from_this();
     app_.getJobQueue().addJob(
-        jtREPLAY_DELTA_REQUEST, "recvReplayDeltaRequest", [weak, m](Job&) {
+        jtREPLYDLTA_REQ, "recvReplayDeltaRequest", [weak, m](Job&) {
             if (auto peer = weak.lock())
                 peer->getReplayDelta(m);
         });

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -21,7 +21,6 @@
 #include <ripple/app/ledger/InboundLedgers.h>
 #include <ripple/app/ledger/InboundTransactions.h>
 #include <ripple/app/ledger/LedgerMaster.h>
-#include <ripple/app/ledger/LedgerReplayer.h>
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/LoadFeeTrack.h>
 #include <ripple/app/misc/NetworkOPs.h>
@@ -1588,9 +1587,8 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProofPathRequest> const& m)
                 }
                 else
                 {
-                    auto oPacket = std::make_shared<Message>(
-                        reply, protocol::mtPROOF_PATH_RESPONSE);
-                    peer->send(oPacket);
+                    peer->send(std::make_shared<Message>(
+                        reply, protocol::mtPROOF_PATH_RESPONSE));
                 }
             }
         });
@@ -1638,9 +1636,8 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMReplayDeltaRequest> const& m)
                 }
                 else
                 {
-                    auto oPacket = std::make_shared<Message>(
-                        reply, protocol::mtREPLAY_DELTA_RESPONSE);
-                    peer->send(oPacket);
+                    peer->send(std::make_shared<Message>(
+                        reply, protocol::mtREPLAY_DELTA_RESPONSE));
                 }
             }
         });

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1702,8 +1702,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMReplayDeltaResponse> const& m)
     }
 
     if (txMap.getHash().as_uint256() != info.txHash)
-    // TODO confirm if work for 0 Txns
-    // reply.transaction_size() == 0, info.txHash.isZero()
     {
         JLOG(p_journal_.trace()) << "Bad message: Transactions verify failed";
         return;

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -94,7 +94,7 @@ PeerImp::PeerImp(
     , compressionEnabled_(
           headers_["X-Offer-Compression"] == "lz4" ? Compressed::On
                                                    : Compressed::Off)
-    , ledgerReplayMsgHandler_(app, app.getLedgerReplayer())
+    , ledgerReplayMsgHandler_(app)
 {
 }
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -98,7 +98,7 @@ PeerImp::PeerImp(
           headers_["X-Offer-LedgerReplay"] == "1" && app_.config().LEDGER_REPLAY
               ? true
               : false)
-    , ledgerReplayMsgHandler_(app)
+    , ledgerReplayMsgHandler_(app, app.getLedgerReplayer())
 {
 }
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1552,6 +1552,102 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMGetLedger> const& m)
 }
 
 void
+PeerImp::onMessage(std::shared_ptr<protocol::TMProofPathRequest> const& m)
+{
+    JLOG(p_journal_.trace()) << "onMessage, TMProofPathRequest";
+    fee_ = Resource::feeMediumBurdenPeer;  // TODO understand
+    std::weak_ptr<PeerImp> weak = shared_from_this();
+    app_.getJobQueue().addJob(
+        jtPROOF_PATH_REQUEST, "recvProofPathRequest", [weak, m](Job&) {
+            if (auto peer = weak.lock())
+                peer->getProofPath(m);
+        });
+}
+
+// TODO how to unit test
+void
+PeerImp::onMessage(std::shared_ptr<protocol::TMProofPathResponse> const& m)
+{
+    JLOG(p_journal_.trace()) << "onMessage, TMProofPathResponse";
+    protocol::TMProofPathResponse& reply = *m;
+    if (reply.has_error() || !reply.has_key() || !reply.has_ledgerheader() ||
+        reply.path_size() == 0)
+        // TODO handle error
+        return;
+
+    std::vector<Blob> path;
+    path.reserve(reply.path_size());
+    for (int i = 0; i < reply.path_size(); ++i)
+    {
+        path.emplace_back(reply.path(i).begin(), reply.path(i).end());
+    }
+    auto info = deserializeHeader(
+        {reply.ledgerheader().data(), reply.ledgerheader().size()});
+
+    if (!SHAMap::verifyProofPath(info.accountHash, keylet::skip().key, path))
+        // TODO handle error
+        return;
+
+    // TODO shorten the deserialize code??
+    auto node = SHAMapAbstractNode::makeFromWire(makeSlice(path.front()));
+    if (!node || !node->isLeaf())
+        // TODO handle error
+        return;
+
+    auto item = static_cast<SHAMapTreeNode*>(node.get())->peekItem();
+    if (!item)
+        // TODO handle error
+        return;
+
+    // TODO call handler with info and item, in handler call
+    // TODO calculateLedgerHash(info) and check if the hashes match
+}
+
+void
+PeerImp::onMessage(std::shared_ptr<protocol::TMReplayDeltaRequest> const& m)
+{
+    JLOG(p_journal_.trace()) << "onMessage, TMReplayDeltaRequest";
+    fee_ = Resource::feeMediumBurdenPeer;
+    std::weak_ptr<PeerImp> weak = shared_from_this();
+    app_.getJobQueue().addJob(
+        jtREPLAY_DELTA_REQUEST, "recvReplayDeltaRequest", [weak, m](Job&) {
+            if (auto peer = weak.lock())
+                peer->getReplayDelta(m);
+        });
+}
+
+void
+PeerImp::onMessage(std::shared_ptr<protocol::TMReplayDeltaResponse> const& m)
+{
+    protocol::TMReplayDeltaResponse& reply = *m;
+    if (reply.has_error() || !reply.has_ledgerheader())
+        // TODO handle error
+        return;
+
+    auto info = deserializeHeader(
+        {reply.ledgerheader().data(), reply.ledgerheader().size()});
+    auto numTxns = reply.transaction_size();
+    if (numTxns == 0 && info.txHash.isNonZero())
+        // TODO confirm txHash is zero if no Tx
+        // TODO handle error
+        return;
+
+    std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns;
+    for (int i = 0; i < numTxns; ++i)
+    {
+        SerialIter sit(makeSlice(reply.transaction(i)));
+        auto tx = std::make_shared<STTx const>(sit);
+        if (!tx)
+            // TODO handle error
+            return;
+        orderedTxns.emplace(i, std::move(tx));
+    }
+
+    // TODO call handler with info and orderedTxns, in handler call
+    // TODO calculateLedgerHash(info) and check if the hashes match
+}
+
+void
 PeerImp::onMessage(std::shared_ptr<protocol::TMLedgerData> const& m)
 {
     protocol::TMLedgerData& packet = *m;
@@ -2981,6 +3077,32 @@ PeerImp::Metrics::total_bytes() const
 {
     std::shared_lock lock{mutex_};
     return totalBytes_;
+}
+
+void
+PeerImp::getProofPath(
+    std::shared_ptr<protocol::TMProofPathRequest> const& request)
+{
+    auto reply = app_.getLedgerMaster().getProofPathResponse(request);
+    if (reply.has_error() &&
+        reply.error() == protocol::TMReplyError::reBAD_REQUEST)
+        charge(Resource::feeInvalidRequest);
+    auto oPacket =
+        std::make_shared<Message>(reply, protocol::mtProofPathResponse);
+    send(oPacket);
+}
+
+void
+PeerImp::getReplayDelta(
+    std::shared_ptr<protocol::TMReplayDeltaRequest> const& request)
+{
+    auto reply = app_.getLedgerMaster().getReplayDeltaResponse(request);
+    if (reply.has_error() &&
+        reply.error() == protocol::TMReplyError::reBAD_REQUEST)
+        charge(Resource::feeInvalidRequest);
+    auto oPacket =
+        std::make_shared<Message>(reply, protocol::mtReplayDeltaResponse);
+    send(oPacket);
 }
 
 }  // namespace ripple

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -661,7 +661,7 @@ PeerImp::PeerImp(
           headers_["X-Offer-LedgerReplay"] == "1" && app_.config().LEDGER_REPLAY
               ? true
               : false)
-    , ledgerReplayMsgHandler_(app)
+    , ledgerReplayMsgHandler_(app, app.getLedgerReplayer())
 {
     read_buffer_.commit(boost::asio::buffer_copy(
         read_buffer_.prepare(boost::asio::buffer_size(buffers)), buffers));

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -610,22 +610,8 @@ private:
         uint256 const& hash,
         std::shared_ptr<protocol::TMLedgerData> const& pPacket,
         beast::Journal journal);
-
-    /**
-     *
-     * @param request
-     */
-    void
-    getProofPath(std::shared_ptr<protocol::TMProofPathRequest> const& request);
-
-    /**
-     *
-     * @param request
-     */
-    void
-    getReplayDelta(
-        std::shared_ptr<protocol::TMReplayDeltaRequest> const& request);
 };
+
 //------------------------------------------------------------------------------
 
 template <class Buffers>

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -612,14 +612,14 @@ private:
         beast::Journal journal);
 
     /**
-     * //TODO
+     *
      * @param request
      */
     void
     getProofPath(std::shared_ptr<protocol::TMProofPathRequest> const& request);
 
     /**
-     * //TODO
+     *
      * @param request
      */
     void

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -670,7 +670,7 @@ PeerImp::PeerImp(
           headers_["X-Offer-Compression"] == "lz4" && app_.config().COMPRESSION
               ? Compressed::On
               : Compressed::Off)
-    , ledgerReplayMsgHandler_(app, app.getLedgerReplayer())
+    , ledgerReplayMsgHandler_(app)
 {
     read_buffer_.commit(boost::asio::buffer_copy(
         read_buffer_.prepare(boost::asio::buffer_size(buffers)), buffers));

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -196,6 +196,7 @@ private:
     hash_map<PublicKey, ShardInfo> shardInfo_;
 
     Compressed compressionEnabled_ = Compressed::Off;
+    bool ledgerReplayEnabled_ = false;
     LedgerReplayMsgHandler ledgerReplayMsgHandler_;
 
     friend class OverlayImpl;
@@ -656,6 +657,10 @@ PeerImp::PeerImp(
           headers_["X-Offer-Compression"] == "lz4" && app_.config().COMPRESSION
               ? Compressed::On
               : Compressed::Off)
+    , ledgerReplayEnabled_(
+          headers_["X-Offer-LedgerReplay"] == "1" && app_.config().LEDGER_REPLAY
+              ? true
+              : false)
     , ledgerReplayMsgHandler_(app)
 {
     read_buffer_.commit(boost::asio::buffer_copy(

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -21,6 +21,7 @@
 #define RIPPLE_OVERLAY_PEERIMP_H_INCLUDED
 
 #include <ripple/app/consensus/RCLCxPeerPos.h>
+#include <ripple/app/ledger/impl/LedgerReplayMsgHandler.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/RangeSet.h>
 #include <ripple/beast/utility/WrappedSink.h>
@@ -195,6 +196,7 @@ private:
     hash_map<PublicKey, ShardInfo> shardInfo_;
 
     Compressed compressionEnabled_ = Compressed::Off;
+    LedgerReplayMsgHandler ledgerReplayMsgHandler_;
 
     friend class OverlayImpl;
 
@@ -668,6 +670,7 @@ PeerImp::PeerImp(
           headers_["X-Offer-Compression"] == "lz4" && app_.config().COMPRESSION
               ? Compressed::On
               : Compressed::Off)
+    , ledgerReplayMsgHandler_(app, app.getLedgerReplayer())
 {
     read_buffer_.commit(boost::asio::buffer_copy(
         read_buffer_.prepare(boost::asio::buffer_size(buffers)), buffers));

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -549,6 +549,14 @@ public:
     onMessage(std::shared_ptr<protocol::TMValidation> const& m);
     void
     onMessage(std::shared_ptr<protocol::TMGetObjectByHash> const& m);
+    void
+    onMessage(std::shared_ptr<protocol::TMProofPathRequest> const& m);
+    void
+    onMessage(std::shared_ptr<protocol::TMProofPathResponse> const& m);
+    void
+    onMessage(std::shared_ptr<protocol::TMReplayDeltaRequest> const& m);
+    void
+    onMessage(std::shared_ptr<protocol::TMReplayDeltaResponse> const& m);
 
 private:
     State
@@ -600,8 +608,22 @@ private:
         uint256 const& hash,
         std::shared_ptr<protocol::TMLedgerData> const& pPacket,
         beast::Journal journal);
-};
 
+    /**
+     * //TODO
+     * @param request
+     */
+    void
+    getProofPath(std::shared_ptr<protocol::TMProofPathRequest> const& request);
+
+    /**
+     * //TODO
+     * @param request
+     */
+    void
+    getReplayDelta(
+        std::shared_ptr<protocol::TMReplayDeltaRequest> const& request);
+};
 //------------------------------------------------------------------------------
 
 template <class Buffers>

--- a/src/ripple/overlay/impl/PeerSet.cpp
+++ b/src/ripple/overlay/impl/PeerSet.cpp
@@ -31,8 +31,8 @@ public:
 
     PeerSetImpl(Application& app);
 
-    ~PeerSetImpl() override = default;
-
+    //    ~PeerSetImpl() override = default;
+    //
     void
     addPeers(
         std::size_t limit,
@@ -147,17 +147,24 @@ PeerSetImpl::countAddedPeers()
 class PeerSetBuilderImpl : public PeerSetBuilder
 {
 public:
-    virtual std::unique_ptr<PeerSet>
-    build(Application& app) override
+    PeerSetBuilderImpl(Application& app) : app_(app)
     {
-        return std::make_unique<PeerSetImpl>(app);
     }
+
+    virtual std::unique_ptr<PeerSet>
+    build() override
+    {
+        return std::make_unique<PeerSetImpl>(app_);
+    }
+
+private:
+    Application& app_;
 };
 
 std::unique_ptr<PeerSetBuilder>
-make_PeerSetBuilder()
+make_PeerSetBuilder(Application& app)
 {
-    return std::make_unique<PeerSetBuilderImpl>();
+    return std::make_unique<PeerSetBuilderImpl>(app);
 }
 
 }  // namespace ripple

--- a/src/ripple/overlay/impl/PeerSet.cpp
+++ b/src/ripple/overlay/impl/PeerSet.cpp
@@ -31,8 +31,6 @@ public:
 
     PeerSetImpl(Application& app);
 
-    //    ~PeerSetImpl() override = default;
-    //
     void
     addPeers(
         std::size_t limit,
@@ -165,6 +163,54 @@ std::unique_ptr<PeerSetBuilder>
 make_PeerSetBuilder(Application& app)
 {
     return std::make_unique<PeerSetBuilderImpl>(app);
+}
+
+class DummyPeerSet : public PeerSet
+{
+public:
+    DummyPeerSet(Application& app) : j_(app.journal("DummyPeerSet"))
+    {
+    }
+
+    void
+    addPeers(
+        std::size_t limit,
+        std::function<bool(std::shared_ptr<Peer> const&)> hasItem,
+        std::function<void(std::shared_ptr<Peer> const&)> onPeerAdded) override
+    {
+        JLOG(j_.warn()) << "DummyPeerSet addPeers should not be called";
+    }
+
+    void
+    sendRequest(
+        ::google::protobuf::Message const& message,
+        protocol::MessageType type,
+        std::shared_ptr<Peer> const& peer) override
+    {
+        JLOG(j_.warn()) << "DummyPeerSet sendRequest should not be called";
+    }
+
+    void
+    visitAddedPeers(std::function<void(Peer::id_t)> onPeer) override
+    {
+        JLOG(j_.warn()) << "DummyPeerSet visitAddedPeers should not be called";
+    }
+
+    std::size_t
+    countAddedPeers() override
+    {
+        JLOG(j_.warn()) << "DummyPeerSet countAddedPeers should not be called";
+        return 0;
+    }
+
+private:
+    beast::Journal j_;
+};
+
+std::unique_ptr<PeerSet>
+make_DummyPeerSet(Application& app)
+{
+    return std::make_unique<DummyPeerSet>(app);
 }
 
 }  // namespace ripple

--- a/src/ripple/overlay/impl/PeerSet.cpp
+++ b/src/ripple/overlay/impl/PeerSet.cpp
@@ -125,10 +125,11 @@ PeerSet::invokeOnTimer()
 
 void
 PeerSet::sendRequest(
-    const protocol::TMGetLedger& tmGL,
+    std::shared_ptr<Message> const&
+        packet,  // const protocol::TMGetLedger& tmGL,
     std::shared_ptr<Peer> const& peer)
 {
-    auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
+    //    auto packet = std::make_shared<Message>(tmGL, protocol::mtGET_LEDGER);
 
     if (peer)
     {

--- a/src/ripple/overlay/impl/ProtocolMessage.h
+++ b/src/ripple/overlay/impl/ProtocolMessage.h
@@ -77,6 +77,14 @@ protocolMessageName(int type)
             return "validation";
         case protocol::mtGET_OBJECTS:
             return "get_objects";
+        case protocol::mtProofPathRequest:
+            return "proof_path_request";
+        case protocol::mtProofPathResponse:
+            return "proof_path_response";
+        case protocol::mtReplayDeltaRequest:
+            return "replay_delta_request";
+        case protocol::mtReplayDeltaResponse:
+            return "replay_delta_response";
         default:
             break;
     }
@@ -373,6 +381,22 @@ invokeProtocolMessage(Buffers const& buffers, Handler& handler)
             break;
         case protocol::mtGET_OBJECTS:
             success = detail::invoke<protocol::TMGetObjectByHash>(
+                *header, buffers, handler);
+            break;
+        case protocol::mtProofPathRequest:
+            success = detail::invoke<protocol::TMProofPathRequest>(
+                *header, buffers, handler);
+            break;
+        case protocol::mtProofPathResponse:
+            success = detail::invoke<protocol::TMProofPathResponse>(
+                *header, buffers, handler);
+            break;
+        case protocol::mtReplayDeltaRequest:
+            success = detail::invoke<protocol::TMReplayDeltaRequest>(
+                *header, buffers, handler);
+            break;
+        case protocol::mtReplayDeltaResponse:
+            success = detail::invoke<protocol::TMReplayDeltaResponse>(
                 *header, buffers, handler);
             break;
         default:

--- a/src/ripple/overlay/impl/ProtocolMessage.h
+++ b/src/ripple/overlay/impl/ProtocolMessage.h
@@ -77,13 +77,13 @@ protocolMessageName(int type)
             return "validation";
         case protocol::mtGET_OBJECTS:
             return "get_objects";
-        case protocol::mtProofPathRequest:
+        case protocol::mtPROOF_PATH_REQ:
             return "proof_path_request";
-        case protocol::mtProofPathResponse:
+        case protocol::mtPROOF_PATH_RESPONSE:
             return "proof_path_response";
-        case protocol::mtReplayDeltaRequest:
+        case protocol::mtREPLAY_DELTA_REQ:
             return "replay_delta_request";
-        case protocol::mtReplayDeltaResponse:
+        case protocol::mtREPLAY_DELTA_RESPONSE:
             return "replay_delta_response";
         default:
             break;
@@ -383,19 +383,19 @@ invokeProtocolMessage(Buffers const& buffers, Handler& handler)
             success = detail::invoke<protocol::TMGetObjectByHash>(
                 *header, buffers, handler);
             break;
-        case protocol::mtProofPathRequest:
+        case protocol::mtPROOF_PATH_REQ:
             success = detail::invoke<protocol::TMProofPathRequest>(
                 *header, buffers, handler);
             break;
-        case protocol::mtProofPathResponse:
+        case protocol::mtPROOF_PATH_RESPONSE:
             success = detail::invoke<protocol::TMProofPathResponse>(
                 *header, buffers, handler);
             break;
-        case protocol::mtReplayDeltaRequest:
+        case protocol::mtREPLAY_DELTA_REQ:
             success = detail::invoke<protocol::TMReplayDeltaRequest>(
                 *header, buffers, handler);
             break;
-        case protocol::mtReplayDeltaResponse:
+        case protocol::mtREPLAY_DELTA_RESPONSE:
             success = detail::invoke<protocol::TMReplayDeltaResponse>(
                 *header, buffers, handler);
             break;

--- a/src/ripple/overlay/impl/TrafficCount.cpp
+++ b/src/ripple/overlay/impl/TrafficCount.cpp
@@ -141,6 +141,18 @@ TrafficCount::categorize(
                                          : TrafficCount::category::get_hash;
     }
 
+    if (type == protocol::mtPROOF_PATH_REQ)
+        return TrafficCount::category::proof_path_request;
+
+    if (type == protocol::mtPROOF_PATH_RESPONSE)
+        return TrafficCount::category::proof_path_response;
+
+    if (type == protocol::mtREPLAY_DELTA_REQ)
+        return TrafficCount::category::replay_delta_request;
+
+    if (type == protocol::mtREPLAY_DELTA_RESPONSE)
+        return TrafficCount::category::replay_delta_response;
+
     return TrafficCount::category::unknown;
 }
 

--- a/src/ripple/overlay/impl/TrafficCount.h
+++ b/src/ripple/overlay/impl/TrafficCount.h
@@ -140,6 +140,14 @@ public:
         share_hash,
         get_hash,
 
+        // TMProofPathRequest and TMProofPathResponse
+        proof_path_request,
+        proof_path_response,
+
+        // TMReplayDeltaRequest and TMReplayDeltaResponse
+        replay_delta_request,
+        replay_delta_response,
+
         unknown  // must be last
     };
 
@@ -224,6 +232,10 @@ protected:
         {"getobject_Fetch Pack_get"},            // category::get_fetch_pack
         {"getobject_share"},                     // category::share_hash
         {"getobject_get"},                       // category::get_hash
+        {"proof_path_request"},                  // category::proof_path_request
+        {"proof_path_response"},                 // category::proof_path_response
+        {"replay_delta_request"},                // category::replay_delta_request
+        {"replay_delta_response"},               // category::replay_delta_response
         {"unknown"}                              // category::unknown
     }};
 };

--- a/src/ripple/overlay/impl/TrafficCount.h
+++ b/src/ripple/overlay/impl/TrafficCount.h
@@ -233,10 +233,10 @@ protected:
         {"getobject_share"},                     // category::share_hash
         {"getobject_get"},                       // category::get_hash
         {"proof_path_request"},                  // category::proof_path_request
-        {"proof_path_response"},                 // category::proof_path_response
-        {"replay_delta_request"},                // category::replay_delta_request
-        {"replay_delta_response"},               // category::replay_delta_response
-        {"unknown"}                              // category::unknown
+        {"proof_path_response"},    // category::proof_path_response
+        {"replay_delta_request"},   // category::replay_delta_request
+        {"replay_delta_response"},  // category::replay_delta_response
+        {"unknown"}                 // category::unknown
     }};
 };
 

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -376,9 +376,9 @@ message TMProofPathRequest
 
 message TMProofPathResponse
 {
-    optional bytes key = 1;
-    optional bytes ledgerHash = 2;
-    optional TMLedgerMapType type = 3;
+    required bytes key = 1;
+    required bytes ledgerHash = 2;
+    required TMLedgerMapType type = 3;
     optional bytes ledgerHeader = 4;
     repeated bytes path = 5;
     optional TMReplyError error = 6;
@@ -391,7 +391,7 @@ message TMReplayDeltaRequest
 
 message TMReplayDeltaResponse
 {
-    optional bytes ledgerHash = 1;
+    required bytes ledgerHash = 1;
     optional bytes ledgerHeader = 2;
     repeated bytes transaction = 3;
     optional TMReplyError error = 4;

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -363,8 +363,8 @@ message TMPing
 
 enum TMLedgerMapType
 {
-    lmTX_NODE = 1;        // transaction node
-    lmAS_NODE = 2;        // account state node
+    lmTX = 1;        // transaction map
+    lmAS = 2;        // account state map
 }
 
 message TMProofPathRequest

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -23,6 +23,10 @@ enum MessageType
     mtGET_PEER_SHARD_INFO   = 52;
     mtPEER_SHARD_INFO       = 53;
     mtVALIDATORLIST         = 54;
+    mtProofPathRequest      = 55;
+    mtProofPathResponse     = 56;
+    mtReplayDeltaRequest    = 57;
+    mtReplayDeltaResponse   = 58;
 }
 
 // token, iterations, target, challenge = issue demand for proof of work
@@ -332,6 +336,7 @@ enum TMReplyError
 {
     reNO_LEDGER                     = 1;    // We don't have the ledger you are asking about
     reNO_NODE                       = 2;    // We don't have any of the nodes you are asking for
+    reBAD_REQUEST                   = 3;    // The request is wrong, e.g. wrong format
 }
 
 message TMLedgerData
@@ -354,5 +359,40 @@ message TMPing
     optional uint32 seq         = 2; // detect stale replies, ensure other side is reading
     optional uint64 pingTime    = 3; // know when we think we sent the ping
     optional uint64 netTime     = 4;
+}
+
+enum TMLedgerMapType
+{
+    lmTX_NODE = 1;        // transaction node
+    lmAS_NODE = 2;        // account state node
+}
+
+message TMProofPathRequest
+{
+    required bytes key = 1;
+    required bytes ledgerHash = 2;
+    required TMLedgerMapType type = 3;
+}
+
+message TMProofPathResponse
+{
+    optional bytes key = 1;
+    optional bytes ledgerHash = 2;
+    optional bytes ledgerHeader = 3;
+    repeated bytes path = 4;
+    optional TMReplyError error = 5;
+}
+
+message TMReplayDeltaRequest
+{
+    required bytes ledgerHash = 1;
+}
+
+message TMReplayDeltaResponse
+{
+    optional bytes ledgerHash = 1;
+    optional bytes ledgerHeader = 2;
+    repeated bytes transaction = 3;
+    optional TMReplyError error = 4;
 }
 

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -378,9 +378,10 @@ message TMProofPathResponse
 {
     optional bytes key = 1;
     optional bytes ledgerHash = 2;
-    optional bytes ledgerHeader = 3;
-    repeated bytes path = 4;
-    optional TMReplyError error = 5;
+    optional TMLedgerMapType type = 3;
+    optional bytes ledgerHeader = 4;
+    repeated bytes path = 5;
+    optional TMReplyError error = 6;
 }
 
 message TMReplayDeltaRequest

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -23,10 +23,10 @@ enum MessageType
     mtGET_PEER_SHARD_INFO   = 52;
     mtPEER_SHARD_INFO       = 53;
     mtVALIDATORLIST         = 54;
-    mtProofPathRequest      = 55;
-    mtProofPathResponse     = 56;
-    mtReplayDeltaRequest    = 57;
-    mtReplayDeltaResponse   = 58;
+    mtPROOF_PATH_REQ        = 55;
+    mtPROOF_PATH_RESPONSE   = 56;
+    mtREPLAY_DELTA_REQ      = 57;
+    mtREPLAY_DELTA_RESPONSE = 58;
 }
 
 // token, iterations, target, challenge = issue demand for proof of work

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -238,6 +238,29 @@ public:
         bool fatLeaves,
         std::uint32_t depth) const;
 
+    // TODO
+    /**
+     *
+     * @param key
+     * @return
+     */
+    std::optional<std::vector<Blob>>
+    getProofPath(uint256 const& key) const;
+
+    // TODO
+    /**
+     *
+     * @param rootHash
+     * @param key
+     * @param path
+     * @return
+     */
+    static bool
+    verifyProofPath(
+        uint256 const& rootHash,
+        uint256 const& key,
+        std::vector<Blob> const& path);
+
     bool
     getRootNode(Serializer& s, SHANodeFormat format) const;
     std::vector<uint256>

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -238,22 +238,20 @@ public:
         bool fatLeaves,
         std::uint32_t depth) const;
 
-    // TODO
     /**
-     *
-     * @param key
-     * @return
+     * Get the proof path (from the leaf to the root with siblings) of the key
+     * @param key  key of the leaf
+     * @return the proof path if found
      */
     std::optional<std::vector<Blob>>
     getProofPath(uint256 const& key) const;
 
-    // TODO
     /**
-     *
-     * @param rootHash
-     * @param key
-     * @param path
-     * @return
+     * Verify the proof path
+     * @param rootHash  root hash of the map
+     * @param key  key of the leaf
+     * @param path  the proof path
+     * @return true if verified successfully
      */
     static bool
     verifyProofPath(

--- a/src/ripple/shamap/SHAMapNodeID.h
+++ b/src/ripple/shamap/SHAMapNodeID.h
@@ -84,6 +84,9 @@ public:
     bool
     has_common_prefix(SHAMapNodeID const& other) const;
 
+    static SHAMapNodeID
+    createID(int depth, uint256 const& hash);
+
 private:
     static uint256 const&
     Masks(int depth);

--- a/src/ripple/shamap/impl/SHAMapNodeID.cpp
+++ b/src/ripple/shamap/impl/SHAMapNodeID.cpp
@@ -151,4 +151,11 @@ SHAMapNodeID::dump(beast::Journal journal) const
     JLOG(journal.debug()) << getString();
 }
 
+SHAMapNodeID
+SHAMapNodeID::createID(int depth, uint256 const& hash)
+{
+    assert((depth >= 0) && (depth < 65));
+    return SHAMapNodeID(depth, hash & Masks(depth));
+}
+
 }  // namespace ripple

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -838,4 +838,75 @@ SHAMap::getFetchPack(
         });
 }
 
+std::optional<std::vector<Blob>>
+SHAMap::getProofPath(uint256 const& key) const
+{
+    SharedPtrNodeStack stack;
+    walkTowardsKey(key, &stack);
+
+    if (stack.empty())
+    {
+        JLOG(journal_.debug()) << "Do not have node with key " << key;
+        return {};
+    }
+
+    if (auto const& [node, nodeID] = stack.top(); !node || node->isInner() ||
+        nodeID != SHAMapNodeID::createID(stack.size() - 1, key))
+    {
+        JLOG(journal_.debug()) << "walkTowardsKey error " << key;
+        return {};
+    }
+
+    std::vector<Blob> path;
+    path.reserve(stack.size());
+    while (!stack.empty())
+    {
+        Serializer s;
+        stack.top().first->addRaw(s, snfWIRE);
+        path.emplace_back(std::move(s.modData()));
+        stack.pop();
+    }
+
+    JLOG(journal_.debug()) << "getPath for key " << key << ", path length "
+                           << path.size();
+    return path;
+}
+
+bool
+SHAMap::verifyProofPath(
+    uint256 const& rootHash,
+    uint256 const& key,
+    std::vector<Blob> const& path)
+{
+    if (path.empty() || path.size() > 65)
+        return false;
+
+    SHAMapHash hash{rootHash};
+    auto pathLen = path.size();
+    for (int depth = 0; depth < pathLen; ++depth)
+    {
+        int depthToIndex = pathLen - 1 - depth;
+        auto const& blob = path[depthToIndex];
+        auto node = SHAMapAbstractNode::makeFromWire(makeSlice(blob));
+        if (!node)
+            return false;
+        node->updateHash();
+        if (node->getNodeHash() != hash)
+            return false;
+
+        if (node->isInner())
+        {
+            auto nodeId = SHAMapNodeID::createID(depth, key);
+            hash = static_cast<SHAMapInnerNode*>(node.get())
+                       ->getChildHash(nodeId.selectBranch(key));
+        }
+        else
+        {
+            // should exhaust all the blobs now
+            return depth + 1 == pathLen;
+        }
+    }
+    return false;
+}
+
 }  // namespace ripple

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -413,9 +413,12 @@ logAll(
 void
 shortenTimeouts()
 {
-    *const_cast<std::chrono::milliseconds *>(&LedgerReplayTask::TASK_TIMEOUT) = 5ms;
-    *const_cast<std::chrono::milliseconds *>(&LedgerReplayTask::SUB_TASK_TIMEOUT) = 2ms;
-    *const_cast<int *>(&LedgerReplayTask::SUB_TASK_MAX_TIMEOUTS) = 3;
+    *const_cast<std::chrono::milliseconds*>(&LedgerReplayer::TASK_TIMEOUT) =
+        5ms;
+    *const_cast<std::chrono::milliseconds*>(&LedgerReplayer::SUB_TASK_TIMEOUT) =
+        2ms;
+    *const_cast<int*>(&LedgerReplayer::TASK_MAX_TIMEOUTS_MULTIPLIER) = 1;
+    *const_cast<int*>(&LedgerReplayer::SUB_TASK_MAX_TIMEOUTS) = 3;
 };
 
 struct LedgerForwardReplay_test : public beast::unit_test::suite
@@ -425,30 +428,28 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
     {
         testcase("simple test");
         int totalReplay = 5;
-        LedgerServer server(*this, {totalReplay+1});
+        LedgerServer server(*this, {totalReplay + 1});
         incPorts();
         ReplayClient client(*this, server);
         auto l = server.ledgerMaster.getClosedLedger();
         auto finalHash = l->info().hash;
-        for(int i = 0; i < totalReplay - 1; ++i)
+        for (int i = 0; i < totalReplay - 1; ++i)
         {
             l = server.ledgerMaster.getLedgerByHash(l->info().parentHash);
         }
         client.ledgerMaster.storeLedger(l);
         logAll(server, client);
         client.replayer.replay(
-            InboundLedger::Reason::GENERIC,
-            finalHash,
-            totalReplay);
+            InboundLedger::Reason::GENERIC, finalHash, totalReplay);
         l = client.ledgerMaster.getLedgerByHash(finalHash);
         BEAST_EXPECT(l);
-        if(l)
+        if (l)
         {
-            for(int i = 0; i < totalReplay - 1; ++i)
+            for (int i = 0; i < totalReplay - 1; ++i)
             {
                 l = client.ledgerMaster.getLedgerByHash(l->info().parentHash);
                 BEAST_EXPECT(l);
-                if(!l)
+                if (!l)
                     break;
             }
         }
@@ -721,13 +722,12 @@ enable=0
     run() override
     {
         testSimple();
-        testMsgDrop(20);
+        //        testMsgDrop(20);
         //        testSkipList();
         //        testLedgerReplayBuild();
         //        testLedgerDeltaReplayBuild();
         //        testLedgerDeltaReplayBuild(0);
         //        testConfig();
-
     }
 };
 

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -415,7 +415,7 @@ shortenTimeouts()
     const_cast<milliseconds&>(LedgerReplayer::SUB_TASK_TIMEOUT) = 2ms;
     const_cast<int&>(LedgerReplayer::TASK_MAX_TIMEOUTS_MULTIPLIER) = 1;
     const_cast<int&>(LedgerReplayer::SUB_TASK_MAX_TIMEOUTS) = 3;
-};//TODO UB?
+};  // TODO UB?
 
 struct LedgerForwardReplay_test : public beast::unit_test::suite
 {

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -411,11 +411,11 @@ using namespace std::chrono;
 void
 shortenTimeouts()
 {
-    *const_cast<milliseconds*>(&LedgerReplayer::TASK_TIMEOUT) = 5ms;
-    *const_cast<milliseconds*>(&LedgerReplayer::SUB_TASK_TIMEOUT) = 2ms;
-    *const_cast<int*>(&LedgerReplayer::TASK_MAX_TIMEOUTS_MULTIPLIER) = 1;
-    *const_cast<int*>(&LedgerReplayer::SUB_TASK_MAX_TIMEOUTS) = 3;
-};
+    const_cast<milliseconds&>(LedgerReplayer::TASK_TIMEOUT) = 5ms;
+    const_cast<milliseconds&>(LedgerReplayer::SUB_TASK_TIMEOUT) = 2ms;
+    const_cast<int&>(LedgerReplayer::TASK_MAX_TIMEOUTS_MULTIPLIER) = 1;
+    const_cast<int&>(LedgerReplayer::SUB_TASK_MAX_TIMEOUTS) = 3;
+};//TODO UB?
 
 struct LedgerForwardReplay_test : public beast::unit_test::suite
 {
@@ -462,7 +462,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
     void
     testMsgDrop(int dropRate)
     {
-        testcase("drop all msg test");
+        testcase("drop msg test");
         int totalReplay = 5;
         LedgerServer server(*this, {totalReplay + 1});
         incPorts();

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -266,7 +266,7 @@ struct LedgerServer
     struct Parameter
     {
         int initLedgers;
-        int initAccounts = 10;
+        int initAccounts = 2;
         int initAmount = 1'000'000;
         int numTxPerLedger = 10;
         int txAmount = 10;
@@ -427,7 +427,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
     testSimple()
     {
         testcase("simple test");
-        int totalReplay = 5;
+        int totalReplay = 3;
         LedgerServer server(*this, {totalReplay + 1});
         incPorts();
         ReplayClient client(*this, server);
@@ -441,6 +441,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
         logAll(server, client);
         client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
+
         l = client.ledgerMaster.getLedgerByHash(finalHash);
         BEAST_EXPECT(l);
         if (l)
@@ -453,6 +454,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
                     break;
             }
         }
+        client.replayer.sweep();
     }
 
     void

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -154,9 +154,9 @@ struct NetworkHistory
     jtx::Env env;
     Parameter param;
     std::vector<jtx::Account> accounts;
-    LedgerMaster& ledgerMaster;
 };
 
+#if 0
 struct LedgerForwardReplay_test : public beast::unit_test::suite
 {
     void
@@ -413,3 +413,4 @@ BEAST_DEFINE_TESTSUITE(LedgerForwardReplay, app, ripple);
 
 }  // namespace test
 }  // namespace ripple
+#endif

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -266,10 +266,13 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
     }
 
     void
-    testLedgerDeltaReplayBuild()
+    testLedgerDeltaReplayBuild(int numTxPerLedger = 10)
     {
         testcase("ledger delta replay build");
-        NetworkHistory history(*this, {3});
+        NetworkHistory::Parameter p = {3};
+        p.numTxPerLedger = numTxPerLedger;
+        NetworkHistory history(*this, p);
+
         auto const l = history.ledgerMaster.getClosedLedger();
         auto const parent =
             history.ledgerMaster.getLedgerByHash(l->info().parentHash);
@@ -292,7 +295,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
 
         // verify the transaction size
         auto numTxns = reply.transaction_size();
-        BEAST_EXPECT(numTxns = history.param.numTxPerLedger);
+        BEAST_EXPECT(numTxns == history.param.numTxPerLedger);
 
         std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns;
         SHAMap txMap(
@@ -370,6 +373,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
         testSkipList();
         testLedgerReplayBuild();
         testLedgerDeltaReplayBuild();
+        testLedgerDeltaReplayBuild(0);
     }
 };
 

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -368,12 +368,43 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
     }
 
     void
+    testConfig()
+    {
+        testcase("ledger replay config test");
+        {
+            Config c;
+            BEAST_EXPECT(c.LEDGER_REPLAY_ENABLE == false);
+        }
+
+        {
+            Config c;
+            std::string toLoad(R"rippleConfig(
+[ledger_replay]
+enable=1
+)rippleConfig");
+            c.loadFromString(toLoad);
+            BEAST_EXPECT(c.LEDGER_REPLAY_ENABLE == true);
+        }
+
+        {
+            Config c;
+            std::string toLoad = (R"rippleConfig(
+[ledger_replay]
+enable=0
+)rippleConfig");
+            c.loadFromString(toLoad);
+            BEAST_EXPECT(c.LEDGER_REPLAY_ENABLE == false);
+        }
+    }
+
+    void
     run() override
     {
         testSkipList();
         testLedgerReplayBuild();
         testLedgerDeltaReplayBuild();
         testLedgerDeltaReplayBuild(0);
+        testConfig();
     }
 };
 

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -379,9 +379,7 @@ struct LedgerReplayClient
         , clientMsgHandler(env.app())
     {
         replayer.peerSetBuilder_ = std::make_unique<ReplayPeerSetBuilder>(
-                  clientMsgHandler,
-                  serverMsgHandler,
-                  drop);
+            clientMsgHandler, serverMsgHandler, drop);
     }
 
     void
@@ -477,7 +475,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
             l = server.ledgerMaster.getLedgerByHash(l->info().parentHash);
         }
         client.ledgerMaster.storeLedger(l);
-        //logAll(server, client);
+        // logAll(server, client);
         client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
         int totalWait = 10;
@@ -497,7 +495,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
         LedgerServer server(*this, {totalReplay + 1});
         incPorts();
         LedgerReplayClient client(*this, server);
-        logAll(server, client, Severity::kAll);
+        logAll(server, client);
         auto l = server.ledgerMaster.getClosedLedger();
         auto finalHash = l->info().hash;
         auto prevHash = l->info().parentHash;
@@ -508,7 +506,7 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
         client.ledgerMaster.storeLedger(l);
 
         client.replayer.replay(
-            InboundLedger::Reason::GENERIC, prevHash, totalReplay-1);
+            InboundLedger::Reason::GENERIC, prevHash, totalReplay - 1);
         client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
 
@@ -764,8 +762,8 @@ enable=0
     void
     run() override
     {
-//        testSimple();
-//        testMsgDrop(20);
+        testSimple();
+        testMsgDrop(20);
         testOverlap();
         //        testLedgerReplayBuild();
         //        testLedgerDeltaReplayBuild();

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -824,7 +824,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             auto request = std::make_shared<protocol::TMProofPathRequest>();
             request->set_ledgerhash(
                 l->info().hash.data(), l->info().hash.size());
-            request->set_type(protocol::TMLedgerMapType::lmAS_NODE);
+            request->set_type(protocol::TMLedgerMapType::lmAS);
             auto reply = std::make_shared<protocol::TMProofPathResponse>(
                 server.msgHandler.processProofPathRequest(request));
             BEAST_EXPECT(reply->has_error());
@@ -833,7 +833,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
         {
             // request, wrong hash
             auto request = std::make_shared<protocol::TMProofPathRequest>();
-            request->set_type(protocol::TMLedgerMapType::lmAS_NODE);
+            request->set_type(protocol::TMLedgerMapType::lmAS);
             request->set_key(
                 keylet::skip().key.data(), keylet::skip().key.size());
             uint256 hash(1234567);
@@ -848,7 +848,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             auto request = std::make_shared<protocol::TMProofPathRequest>();
             request->set_ledgerhash(
                 l->info().hash.data(), l->info().hash.size());
-            request->set_type(protocol::TMLedgerMapType::lmAS_NODE);
+            request->set_type(protocol::TMLedgerMapType::lmAS);
             request->set_key(
                 keylet::skip().key.data(), keylet::skip().key.size());
             // generate response
@@ -971,7 +971,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             Config c;
             std::string toLoad(R"rippleConfig(
 [ledger_replay]
-enable=1
+1
 )rippleConfig");
             c.loadFromString(toLoad);
             BEAST_EXPECT(c.LEDGER_REPLAY == true);
@@ -981,7 +981,7 @@ enable=1
             Config c;
             std::string toLoad = (R"rippleConfig(
 [ledger_replay]
-enable=0
+0
 )rippleConfig");
             c.loadFromString(toLoad);
             BEAST_EXPECT(c.LEDGER_REPLAY == false);
@@ -989,10 +989,9 @@ enable=0
     }
 
     void
-    testAllLocal()
+    testAllLocal(int totalReplay)
     {
         testcase("local node has all the ledgers");
-        int totalReplay = 3;
         auto psBhvr = PeerSetBehavior::DropAll;
         auto ilBhvr = InboundLedgersBehavior::DropAll;
         auto peerFeature = PeerFeature::None;
@@ -1032,10 +1031,9 @@ enable=0
     }
 
     void
-    testAllInboundLedgers()
+    testAllInboundLedgers(int totalReplay)
     {
         testcase("all the ledgers from InboundLedgers");
-        int totalReplay = 3;
         NetworkOfTwo net(
             *this,
             {totalReplay + 1},
@@ -1063,7 +1061,7 @@ enable=0
     }
 
     void
-    testPeerSetBehavior(PeerSetBehavior peerSetBehavior)
+    testPeerSetBehavior(PeerSetBehavior peerSetBehavior, int totalReplay = 5)
     {
         switch (peerSetBehavior)
         {
@@ -1080,7 +1078,6 @@ enable=0
                 return;
         }
 
-        int totalReplay = 5;
         NetworkOfTwo net(
             *this,
             {totalReplay + 1},
@@ -1315,8 +1312,11 @@ enable=0
         testReplayDelta();
         testTaskParameter();
         testConfig();
-        testAllLocal();
-        testAllInboundLedgers();
+        testAllLocal(1);
+        testAllLocal(3);
+        testAllInboundLedgers(1);
+        testAllInboundLedgers(4);
+        testPeerSetBehavior(PeerSetBehavior::Good, 1);
         testPeerSetBehavior(PeerSetBehavior::Good);
         testPeerSetBehavior(PeerSetBehavior::Drop50);
         testPeerSetBehavior(PeerSetBehavior::Repeat);

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -20,6 +20,7 @@
 #include <ripple/app/ledger/BuildLedger.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/ledger/LedgerReplay.h>
+#include <ripple/overlay/impl/PeerImp.h>
 #include <test/jtx.h>
 
 namespace ripple {
@@ -57,7 +58,283 @@ struct LedgerReplay_test : public beast::unit_test::suite
     }
 };
 
+/**
+ * Utility class for creating ledger history
+ */
+struct NetworkHistory
+{
+    struct Parameter
+    {
+        int initLedgers;
+        int initAccounts = 10;
+        int initAmount = 1'000'000;
+        int numTxPerLedger = 10;
+        int txAmount = 10;
+    };
+
+    NetworkHistory(beast::unit_test::suite& suite, Parameter const& p)
+        : env(suite, jtx::supported_amendments() | featureNegativeUNL)
+        , param(p)
+        , ledgerMaster(env.app().getLedgerMaster())
+    {
+        assert(param.initLedgers > 0);
+        createAccounts(param.initAccounts);
+        createLedgerHistory();
+    }
+
+    /**
+     * @note close a ledger
+     */
+    void
+    createAccounts(int newAccounts)
+    {
+        auto fundedAccounts = accounts.size();
+        for (int i = 0; i < newAccounts; ++i)
+        {
+            accounts.emplace_back(
+                "alice_" + std::to_string(fundedAccounts + i));
+            env.fund(jtx::XRP(param.initAmount), accounts.back());
+        }
+        env.close();
+    }
+
+    /**
+     * @note close a ledger
+     */
+    void
+    sendPayments(int newTxes)
+    {
+        int fundedAccounts = accounts.size();
+        assert(fundedAccounts >= newTxes);
+        std::unordered_set<int> senders;
+
+        // somewhat random but reproducible
+        int r = ledgerMaster.getClosedLedger()->seq() * 7;
+        int fromIdx = 0;
+        int toIdx = 0;
+        auto updateIdx = [&]() {
+            assert(fundedAccounts > senders.size());
+            fromIdx = (fromIdx + r) % fundedAccounts;
+            while (senders.count(fromIdx) != 0)
+                fromIdx = (fromIdx + 1) % fundedAccounts;
+            senders.insert(fromIdx);
+            toIdx = (toIdx + r * 2) % fundedAccounts;
+            if (toIdx == fromIdx)
+                toIdx = (toIdx + 1) % fundedAccounts;
+        };
+
+        for (int i = 0; i < newTxes; ++i)
+        {
+            updateIdx();
+            env.apply(
+                pay(accounts[fromIdx],
+                    accounts[toIdx],
+                    jtx::drops(ledgerMaster.getClosedLedger()->fees().base) +
+                        jtx::XRP(param.txAmount)),
+                jtx::seq(jtx::autofill),
+                jtx::fee(jtx::autofill),
+                jtx::sig(jtx::autofill));
+        }
+        env.close();
+    }
+
+    /**
+     * create ledger history
+     * TODO consider added different kinds of Tx
+     */
+    void
+    createLedgerHistory()
+    {
+        for (int i = 0; i < param.initLedgers - 1; ++i)
+        {
+            sendPayments(param.numTxPerLedger);
+        }
+    }
+
+    jtx::Env env;
+    Parameter param;
+    std::vector<jtx::Account> accounts;
+    LedgerMaster& ledgerMaster;
+};
+
+struct LedgerForwardReplay_test : public beast::unit_test::suite
+{
+    void
+    testSkipList()
+    {
+        testcase("skip list with proof");
+        NetworkHistory history(*this, {3});
+        auto const l = history.ledgerMaster.getClosedLedger();
+
+        // create request
+        auto request = std::make_shared<protocol::TMProofPathRequest>();
+        request->set_ledgerhash(l->info().hash.data(), l->info().hash.size());
+        request->set_key(keylet::skip().key.data(), keylet::skip().key.size());
+        request->set_type(protocol::TMLedgerMapType::lmAS_NODE);
+
+        // generate response
+        auto reply = history.ledgerMaster.getProofPathResponse(request);
+        BEAST_EXPECT(reply.has_ledgerheader());
+        BEAST_EXPECT(!reply.has_error());
+        if (!reply.has_ledgerheader() || reply.has_error())
+            return;
+
+        // verify the header
+        auto info = deserializeHeader(
+            {reply.ledgerheader().data(), reply.ledgerheader().size()});
+        BEAST_EXPECT(calculateLedgerHash(info) == l->info().hash);
+
+        // verify the path
+        std::vector<Blob> path;
+        path.reserve(reply.path_size());
+        for (int i = 0; i < reply.path_size(); ++i)
+        {
+            path.emplace_back(reply.path(i).begin(), reply.path(i).end());
+        }
+        BEAST_EXPECT(SHAMap::verifyProofPath(
+            info.accountHash, keylet::skip().key, path));
+
+        // deserialize the skip list
+        // TODO shorten the deserialize code
+        auto node = SHAMapAbstractNode::makeFromWire(makeSlice(path.front()));
+        BEAST_EXPECT(node);
+        BEAST_EXPECT(node->isLeaf());
+        if (!node || !node->isLeaf())
+            return;
+        auto item = static_cast<SHAMapTreeNode*>(node.get())->peekItem();
+        BEAST_EXPECT(item);
+        if (!item)
+            return;
+        auto sle = std::make_shared<SLE>(
+            SerialIter{item->data(), item->size()}, item->key());
+        BEAST_EXPECT(sle);
+        if (!sle)
+            return;
+        auto const& skipList = sle->getFieldV256(sfHashes).value();
+
+        // verify the skip list
+        std::vector<uint256> hashes;
+        int current = l->seq();
+        for (int seq = std::max(1, current - 256); seq < current; ++seq)
+        {
+            auto ledger = history.ledgerMaster.getLedgerBySeq(seq);
+            BEAST_EXPECT(ledger);
+            if (ledger)
+                hashes.push_back(ledger->info().hash);
+        }
+        BEAST_EXPECT(hashes == skipList);
+    }
+
+    void
+    testLedgerReplayBuild()
+    {
+        testcase("ledger replay build");
+        NetworkHistory history(*this, {3});
+        auto const l = history.ledgerMaster.getClosedLedger();
+        auto const parent =
+            history.ledgerMaster.getLedgerByHash(l->info().parentHash);
+
+        // create LedgerReplay object
+        auto l_replay_temp = std::make_shared<Ledger>(
+            l->info(),
+            history.env.app().config(),
+            history.env.app().getNodeFamily());
+        BEAST_EXPECT(l_replay_temp);
+        if (!l_replay_temp)
+            return;
+        BEAST_EXPECT(l_replay_temp->info().hash == l->info().hash);
+
+        std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns;
+        for (auto const& item : l->txMap())
+        {
+            auto txPair = l->txRead(item.key());
+            auto const txIndex = (*txPair.second)[sfTransactionIndex];
+            orderedTxns.emplace(txIndex, std::move(txPair.first));
+        }
+
+        LedgerReplay replayData(parent, l_replay_temp, std::move(orderedTxns));
+
+        // build ledger
+        auto const l_replayed = buildLedger(
+            replayData, tapNONE, history.env.app(), history.env.journal);
+        BEAST_EXPECT(l_replayed);
+        if (!l_replayed)
+            return;
+
+        // verify ledger, note that hash is calculated in Ledger::setImmutable()
+        BEAST_EXPECT(l_replayed->info().hash == l->info().hash);
+    }
+
+    void
+    testLedgerDeltaReplayBuild()
+    {
+        testcase("ledger delta replay build");
+        NetworkHistory history(*this, {3});
+        auto const l = history.ledgerMaster.getClosedLedger();
+        auto const parent =
+            history.ledgerMaster.getLedgerByHash(l->info().parentHash);
+
+        // create request
+        auto request = std::make_shared<protocol::TMReplayDeltaRequest>();
+        request->set_ledgerhash(l->info().hash.data(), l->info().hash.size());
+
+        // generate response
+        auto reply = history.ledgerMaster.getReplayDeltaResponse(request);
+        BEAST_EXPECT(reply.has_ledgerheader());
+        BEAST_EXPECT(!reply.has_error());
+        if (!reply.has_ledgerheader() || reply.has_error())
+            return;
+
+        // verify the header
+        auto info = deserializeHeader(
+            {reply.ledgerheader().data(), reply.ledgerheader().size()});
+        BEAST_EXPECT(calculateLedgerHash(info) == l->info().hash);
+
+        // verify the transaction size
+        auto numTxns = reply.transaction_size();
+        BEAST_EXPECT(numTxns = history.param.numTxPerLedger);
+
+        std::map<std::uint32_t, std::shared_ptr<STTx const>> orderedTxns;
+        for (int i = 0; i < numTxns; ++i)
+        {
+            SerialIter sit(makeSlice(reply.transaction(i)));
+            auto tx = std::make_shared<STTx const>(sit);
+            BEAST_EXPECT(tx);
+            orderedTxns.emplace(i, std::move(tx));
+        }
+
+        // create LedgerReplay object
+        auto l_replay_temp = std::make_shared<Ledger>(
+            info,
+            history.env.app().config(),
+            history.env.app().getNodeFamily());
+        BEAST_EXPECT(l_replay_temp);
+        if (!l_replay_temp)
+            return;
+        LedgerReplay replayData(parent, l_replay_temp, std::move(orderedTxns));
+
+        // build ledger
+        auto const l_replayed = buildLedger(
+            replayData, tapNONE, history.env.app(), history.env.journal);
+        BEAST_EXPECT(l_replayed);
+        if (!l_replayed)
+            return;
+
+        // verify ledger, note that hash is calculated in Ledger::setImmutable()
+        BEAST_EXPECT(l_replayed->info().hash == l->info().hash);
+    }
+
+    void
+    run() override
+    {
+        testSkipList();
+        testLedgerReplayBuild();
+        testLedgerDeltaReplayBuild();
+    }
+};
+
 BEAST_DEFINE_TESTSUITE(LedgerReplay, app, ripple);
+BEAST_DEFINE_TESTSUITE(LedgerForwardReplay, app, ripple);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -266,7 +266,7 @@ struct LedgerServer
     struct Parameter
     {
         int initLedgers;
-        int initAccounts = 2;
+        int initAccounts = 10;
         int initAmount = 1'000'000;
         int numTxPerLedger = 10;
         int txAmount = 10;
@@ -475,9 +475,12 @@ struct LedgerForwardReplay_test : public beast::unit_test::suite
         logAll(server, client);
         client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
-        while (!client.replayer.skipLists_.empty())
+        int totalWait = 10;
+        while (!client.replayer.tasks_.empty() && totalWait-- > 0)
+        {
+            client.replayer.sweep();
             usleep(1000000);
-
+        }
         BEAST_EXPECT(client.ledgerMaster.getLedgerByHash(finalHash));
     }
 
@@ -724,7 +727,7 @@ enable=0
     run() override
     {
         testSimple();
-        //        testMsgDrop(20);
+        testMsgDrop(20);
         //        testSkipList();
         //        testLedgerReplayBuild();
         //        testLedgerDeltaReplayBuild();

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2018 Ripple Labs Inc.
+    Copyright (c) 2020 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -410,6 +410,14 @@ logAll(
     client.app.logs().threshold(level);
 }
 
+void
+shortenTimeouts()
+{
+    *const_cast<std::chrono::milliseconds *>(&LedgerReplayTask::TASK_TIMEOUT) = 5ms;
+    *const_cast<std::chrono::milliseconds *>(&LedgerReplayTask::SUB_TASK_TIMEOUT) = 2ms;
+    *const_cast<int *>(&LedgerReplayTask::SUB_TASK_MAX_TIMEOUTS) = 3;
+};
+
 struct LedgerForwardReplay_test : public beast::unit_test::suite
 {
     void
@@ -713,12 +721,13 @@ enable=0
     void
     run() override
     {
-        testAllMsgDropped();
+        testMsgDrop();
         //        testSkipList();
         //        testLedgerReplayBuild();
         //        testLedgerDeltaReplayBuild();
         //        testLedgerDeltaReplayBuild(0);
         //        testConfig();
+
     }
 };
 

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -347,7 +347,35 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(SHAMap, ripple_app, ripple);
+class SHAMapPathProof_test : public beast::unit_test::suite
+{
+    void
+    run() override
+    {
+        test::SuiteJournal journal("SHAMapPathProof_test", *this);
 
+        tests::TestNodeFamily tf{journal};
+        SHAMap map{SHAMapType::FREE, tf};
+        map.setUnbacked();
+
+        for (unsigned char c = 1; c < 100; ++c)
+        {
+            uint256 k(c);
+            Blob b(32, c);
+            map.addItem(SHAMapItem{k, b}, false, false);
+            map.invariants();
+
+            auto rootHash = map.getHash().as_uint256();
+            auto path = map.getProofPath(k);
+            BEAST_EXPECT(path);
+            if (!path)
+                break;
+            BEAST_EXPECT(map.verifyProofPath(rootHash, k, *path));
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(SHAMap, ripple_app, ripple);
+BEAST_DEFINE_TESTSUITE(SHAMapPathProof, ripple_app, ripple);
 }  // namespace tests
 }  // namespace ripple


### PR DESCRIPTION
Currently the ledger forward replay prototype:
* added proof path retrieval and verification in SHAMap
* added ProofPathRequest and response, and ReplayDeltaRequest and response messages, and their handlers in PeerImp and LedgerMaster
* modified LedgerReplay to be able to replay ledger deltas
* added some unit tests. Since we don't have the LedgerForwardReplayer class, some of its code such as verifying the skip list and use the LedgerReplay to build ledgers are in the unit tests.

What obviously missing are:
* merge the new message types (ProofPathRequest and response, and ReplayDeltaRequest and response) into TMGetLedger and TMLedgerData if ***fit***.
* the LedgerForwardReplayer that manages a ledger forward replay task by sending messages to peers, and verifying the skip lists and use the LedgerReplay to build ledgers. 
    * or expand InboundLedger
* the code that interfacing with use cases and manages parallel ledger forward replay tasks 
    * likely expand InboundLedgers
