### PR TITLE
Revert "Disable wandalen/wretry for codecov upload"

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -207,11 +207,13 @@ jobs:
           path: coverage.xml
           retention-days: 30
       - name: upload coverage report
-        uses: codecov/codecov-action@v4.1.1
-        with: |
-          file: coverage.xml
-          fail_ci_if_error: true
-          disable_search: true
-          verbose: true
-          os: linux
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: wandalen/wretry.action@v1.3.0
+        with:
+          action: codecov/codecov-action@v4
+          with: |
+            files: coverage.xml
+            fail_ci_if_error: true
+            verbose: true
+            token: ${{ secrets.CODECOV_TOKEN }}
+          attempt_limit: 5
+          attempt_delay: 35000 # in milliseconds


### PR DESCRIPTION
Actual useful fixes are in https://github.com/XRPLF/rippled/pull/4977/ instead